### PR TITLE
feat(tor): command-PID attribution for interception-path tor_control events

### DIFF
--- a/docs/superpowers/plans/2026-06-22-onion-event-pid-attribution.md
+++ b/docs/superpowers/plans/2026-06-22-onion-event-pid-attribution.md
@@ -1,0 +1,542 @@
+# Onion / Connection-Vector Event PID Attribution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded `pid: 0` in the four transparent-interception-path `tor_control` events with the session's current command-process PID.
+
+**Architecture:** Each interception point already holds a `*session.Session` and already reads `sess.CurrentCommandID()`; it additionally reads `sess.CurrentProcessPID()` and passes it where it currently passes the literal `0` to `tor.BuildControlEvent`. The SOCKS gateway path threads a new `pid int` parameter through `handleTorSocks → gatewayConnect/gatewayResolve → emitOnionEvent`. No new event type, config knob, or data path.
+
+**Tech Stack:** Go; `internal/netmonitor` (interceptors), `internal/session` (PID source), `internal/tor` (event builder, unchanged), `internal/policy` (`TorVerdict`).
+
+## Global Constraints
+
+- **No new `events.EventType`** — reuse the existing `"tor_control"` event; the OCSF registry stays untouched.
+- **No new config knobs and no new data path** — behaviour derives entirely from existing session state.
+- **`tor.BuildControlEvent(sessionID, commandID string, pid int, v tor.Verdict)` is unchanged** — it already accepts and stamps `pid`. Only callers change.
+- **Honest semantics:** the value is the session's *current command-process PID* (root of the running command's process tree), not necessarily the exact leaf caller. Each emission site carries a short comment saying so.
+- **Idle session:** when no command is running, `CurrentProcessPID()` returns `0` and `CurrentCommandID()` returns `""`; emit `pid: 0` honestly. No special-casing.
+- **Cross-compile must stay clean:** `GOOS=windows go build ./...` (per AGENTS.md / CLAUDE.md).
+- **PID value used in all tests:** `4242` (arbitrary non-zero sentinel), `0` for idle-case tests.
+
+---
+
+## File Structure
+
+- `internal/netmonitor/socks.go` — add `pid int` to `handleTorSocks`, `gatewayConnect`, `gatewayResolve`, `emitOnionEvent`; pass it to `BuildControlEvent`. (Task 1)
+- `internal/netmonitor/transparent_tcp.go` — in `handleConn`, read `pid` once next to the existing `commandID` read; pass it to `handleTorSocks` (Task 1); reuse it for the `relay_ip`/`socks_port` emission, extracted into a small `emitTorControl` method (Task 2).
+- `internal/netmonitor/dns.go` — read `pid` next to `commandID` in `handle`; pass at the `onion_dns` emission. (Task 3)
+- `internal/netmonitor/proxy.go` — read `pid` next to `commandID` in `handleHTTP`; pass at the `onion_http` emission. (Task 4)
+- Tests: `socks_handler_test.go` (Task 1), `transparent_tcp_test.go` (Task 2), `dns_test.go` (Task 3), `proxy_test.go` (Task 4).
+- `docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md` — status + a verification note. (Task 5)
+
+Reference facts (verified against the tree at base `7dccbb35`):
+- `internal/session/manager.go:379` — `func (s *Session) CurrentProcessPID() int`. The setter is `SetCurrentProcessPID(pid int)` (`:373`); `LockExec`'s release closure clears `currentProcPID = 0` (`:351`), so idle ⇒ `0`.
+- `dec.Tor` is of type `*policy.TorVerdict` (`internal/policy/engine.go:166`), with fields `Vector, Mode, Decision, Target`.
+- All test emitters live in `package netmonitor` (white-box) and are mutually visible: `captureEmitter` (`dns_test.go:15`, has `.events []types.Event`), `stubEmitter` (`proxy_test.go:24`, has `.events`), `torCaptureEmitter` (`socks_handler_test.go:29`).
+- A `*session.Session` is constructible in tests as `&session.Session{ID: "s"}` (see `proxy_test.go:651`); call `sess.SetCurrentProcessPID(4242)` on it.
+
+---
+
+### Task 1: SOCKS onion gateway events carry the command PID
+
+**Files:**
+- Modify: `internal/netmonitor/socks.go` (`handleTorSocks` `:140`, `gatewayConnect` `:173`, `gatewayResolve` `:301`, `emitOnionEvent` `:337`)
+- Modify: `internal/netmonitor/transparent_tcp.go` (`handleConn`, the `commandID` read `:112-115` and the `handleTorSocks` call `:119`)
+- Test: `internal/netmonitor/socks_handler_test.go`
+
+**Interfaces:**
+- Consumes: `session.Session.CurrentProcessPID() int`; `tor.BuildControlEvent(sessionID, commandID string, pid int, v tor.Verdict)`.
+- Produces: new signatures used by later tasks reading from the same `handleConn`:
+  - `handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int) error`
+  - `emitOnionEvent(emit Emitter, sessionID, commandID string, pid int, v tor.Verdict, socksCmd string)`
+  - In `transparent_tcp.go handleConn`, a local `pid int` read once next to `commandID` (Task 2 reuses it).
+
+- [ ] **Step 1: Update the test helper and call sites to assert PID (fails to compile → drives the change)**
+
+In `internal/netmonitor/socks_handler_test.go`, change `assertOnionEvent` to take a wanted PID and assert it:
+
+```go
+func assertOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision, wantCmd string, wantPID int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, ev := range emit.events() {
+			if ev.Type == "tor_control" && ev.Fields["vector"] == tor.VectorOnion {
+				if ev.Fields["decision"] != wantDecision {
+					t.Fatalf("event decision = %v, want %v", ev.Fields["decision"], wantDecision)
+				}
+				if ev.Fields["socks_cmd"] != wantCmd {
+					t.Fatalf("event socks_cmd = %v, want %v", ev.Fields["socks_cmd"], wantCmd)
+				}
+				if ev.PID != wantPID {
+					t.Fatalf("event PID = %d, want %d", ev.PID, wantPID)
+				}
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no tor_control{vector:onion,decision:%s,socks_cmd:%s} event seen", wantDecision, wantCmd)
+}
+```
+
+Update all 7 `assertOnionEvent(...)` call sites to pass `4242` as the final arg (lines ~166, 184, 220, 282, 492, 509, 536): e.g. `assertOnionEvent(t, emit, "allow", "connect", 4242)` and `assertOnionEvent(t, emit, "deny", "resolve", 4242)`.
+
+Update all 8 `handleTorSocks(...)` call sites (lines ~147, 176, 200, 263, 295, 476, 502, 524) to pass `4242` as the final arg, e.g.:
+
+```go
+_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
+```
+
+Add an idle-session test (new PID-0 path) at the end of the file:
+
+```go
+func TestHandleTorSocks_IdleSessionPIDZero(t *testing.T) {
+	upstream, stop := fakeTorUpstream(t)
+	defer stop()
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	go func() {
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "", 0)
+	}()
+	if rep := driveClient(t, client, "ok.onion", 443); rep != 0x00 {
+		t.Fatalf("rep = 0x%02x, want 0x00", rep)
+	}
+	assertOnionEvent(t, emit, "allow", "connect", 0)
+	client.Close()
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run: `go test ./internal/netmonitor/ -run TestHandleTorSocks -count=1`
+Expected: FAIL — compile error, `handleTorSocks`/`emitOnionEvent` called with too many arguments.
+
+- [ ] **Step 3: Thread `pid` through `socks.go`**
+
+In `internal/netmonitor/socks.go`:
+
+`handleTorSocks` signature and its two dispatch calls:
+
+```go
+func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int) error {
+	defer conn.Close()
+
+	if err := readSocksGreeting(conn); err != nil {
+		return err
+	}
+	if err := writeSocksMethod(conn, 0x00); err != nil { // no-auth
+		return err
+	}
+	req, err := readSocksRequest(conn)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+
+	switch req.cmd {
+	case socksCmdConnect:
+		return gatewayConnect(conn, upstreamAddr, pol, emit, sessionID, commandID, pid, req)
+	case socksCmdResolve:
+		return gatewayResolve(conn, upstreamAddr, pol, emit, sessionID, commandID, pid, req)
+	default:
+		_ = writeSocksReply(conn, socksRepCmdNotSupported)
+		return nil
+	}
+}
+```
+
+`gatewayConnect` signature + its `emitOnionEvent` call (leave the rest of the body unchanged):
+
+```go
+func gatewayConnect(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int, req socksReq) error {
+	v, ok := pol.EvalSocksTarget(req.host, req.port)
+	if ok {
+		emitOnionEvent(emit, sessionID, commandID, pid, v, "connect")
+	}
+	// ... unchanged ...
+```
+
+`gatewayResolve` signature + its `emitOnionEvent` call (leave the rest unchanged):
+
+```go
+func gatewayResolve(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int, req socksReq) error {
+	v, ok := pol.EvalSocksTarget(req.host, req.port)
+	if ok {
+		emitOnionEvent(emit, sessionID, commandID, pid, v, "resolve")
+	}
+	// ... unchanged ...
+```
+
+`emitOnionEvent` — accept `pid` and pass it to the builder:
+
+```go
+func emitOnionEvent(emit Emitter, sessionID, commandID string, pid int, v tor.Verdict, socksCmd string) {
+	if emit == nil {
+		return
+	}
+	// pid is the session's current command-process PID (root of the running
+	// command's process tree), not necessarily the exact leaf caller.
+	ev := tor.BuildControlEvent(sessionID, commandID, pid, v)
+	ev.Fields["socks_cmd"] = socksCmd
+	_ = emit.AppendEvent(context.Background(), ev)
+	emit.Publish(ev)
+}
+```
+
+- [ ] **Step 4: Update the production call site in `transparent_tcp.go`**
+
+In `internal/netmonitor/transparent_tcp.go`, `handleConn`, replace the `commandID` read block (`:112-115`) and the `handleTorSocks` call (`:119`):
+
+```go
+	commandID := ""
+	pid := 0
+	if t.sess != nil {
+		commandID = t.sess.CurrentCommandID()
+		pid = t.sess.CurrentProcessPID() // command-process PID; reused by the relay_ip/socks_port emit below
+	}
+	engine := t.policyEngine()
+
+	if cfg, ok := t.torGatewayFor(dstPort); ok {
+		return handleTorSocks(conn, cfg.upstream, cfg.pol, t.emit, t.sessionID, commandID, pid)
+	}
+```
+
+- [ ] **Step 5: Run the SOCKS tests to verify they pass**
+
+Run: `go test ./internal/netmonitor/ -run 'TestHandleTorSocks|TestReadSocksRequest|TestSplice' -count=1`
+Expected: PASS (all gateway tests, including `TestHandleTorSocks_IdleSessionPIDZero`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/netmonitor/socks.go internal/netmonitor/transparent_tcp.go internal/netmonitor/socks_handler_test.go
+git commit -m "feat(tor): onion SOCKS gateway events carry the command-process PID"
+```
+
+---
+
+### Task 2: relay_ip / socks_port event carries the command PID
+
+**Files:**
+- Modify: `internal/netmonitor/transparent_tcp.go` (extract `emitTorControl`; replace the inline emission `:142-148`; reuse the `pid` local from Task 1)
+- Test: `internal/netmonitor/transparent_tcp_test.go`
+
+**Interfaces:**
+- Consumes: the `pid int` local introduced in `handleConn` by Task 1; `dec.Tor` of type `*policy.TorVerdict`.
+- Produces: `func (t *TransparentTCP) emitTorControl(commandID string, pid int, tv *policy.TorVerdict)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/netmonitor/transparent_tcp_test.go` (the package already imports `policy` and `types`; add `captureEmitter` is defined in `dns_test.go`, same package):
+
+```go
+func TestTransparentTCP_TorControlCarriesCommandPID(t *testing.T) {
+	em := &captureEmitter{}
+	tcp := &TransparentTCP{sessionID: "s", emit: em}
+	tcp.emitTorControl("cmd-1", 4242, &policy.TorVerdict{
+		Vector: "relay_ip", Mode: "deny", Decision: "deny", Target: "10.0.0.1:443",
+	})
+	if len(em.events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(em.events))
+	}
+	ev := em.events[0]
+	if ev.Type != "tor_control" {
+		t.Fatalf("type = %q, want tor_control", ev.Type)
+	}
+	if ev.PID != 4242 {
+		t.Fatalf("PID = %d, want 4242", ev.PID)
+	}
+	if ev.Fields["vector"] != "relay_ip" {
+		t.Fatalf("vector = %v, want relay_ip", ev.Fields["vector"])
+	}
+}
+
+func TestTransparentTCP_TorControlIdlePIDZero(t *testing.T) {
+	em := &captureEmitter{}
+	tcp := &TransparentTCP{sessionID: "s", emit: em}
+	tcp.emitTorControl("", 0, &policy.TorVerdict{
+		Vector: "socks_port", Mode: "deny", Decision: "deny", Target: "127.0.0.1:9050",
+	})
+	if len(em.events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(em.events))
+	}
+	if em.events[0].PID != 0 {
+		t.Fatalf("PID = %d, want 0", em.events[0].PID)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/netmonitor/ -run TestTransparentTCP_TorControl -count=1`
+Expected: FAIL — `tcp.emitTorControl undefined`.
+
+- [ ] **Step 3: Extract the method and call it with `pid`**
+
+In `internal/netmonitor/transparent_tcp.go`, add the method (near `handleConn`):
+
+```go
+// emitTorControl publishes a tor_control event for a Tor verdict carried on a
+// connect decision. pid is the session's current command-process PID (root of
+// the running command's process tree), not necessarily the exact leaf caller.
+func (t *TransparentTCP) emitTorControl(commandID string, pid int, tv *policy.TorVerdict) {
+	if tv == nil || t.emit == nil {
+		return
+	}
+	tev := tor.BuildControlEvent(t.sessionID, commandID, pid, tor.Verdict{
+		Vector: tv.Vector, Mode: tv.Mode, Decision: tv.Decision, Target: tv.Target,
+	})
+	_ = t.emit.AppendEvent(context.Background(), tev)
+	t.emit.Publish(tev)
+}
+```
+
+Replace the inline emission block (`:142-148`) with a call that reuses the `pid` local from Task 1:
+
+```go
+	dec := t.checkConnectNetwork(context.Background(), commandID, domain, redirectHostPort, dstIP, dstPort, redirectResult)
+	t.emitTorControl(commandID, pid, dec.Tor)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/netmonitor/ -run TestTransparentTCP -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/netmonitor/transparent_tcp.go internal/netmonitor/transparent_tcp_test.go
+git commit -m "feat(tor): relay_ip/socks_port event carries the command-process PID"
+```
+
+---
+
+### Task 3: onion_dns event carries the command PID
+
+**Files:**
+- Modify: `internal/netmonitor/dns.go` (`handle`, the `commandID` read `:96-99` and the emission `:124`)
+- Test: `internal/netmonitor/dns_test.go` (extend `TestDNSInterceptor_OnionEmitsTorControl`)
+
+**Interfaces:**
+- Consumes: `session.Session.CurrentProcessPID()`.
+- Produces: nothing new; `onion_dns` event now carries `PID`.
+
+- [ ] **Step 1: Extend the existing onion test to set a session PID and assert it**
+
+In `internal/netmonitor/dns_test.go`, in `TestDNSInterceptor_OnionEmitsTorControl`, construct a session with a known PID and attach it to the interceptor, then assert the event PID. Change the `&DNSInterceptor{...}` literal (`:393-399`) to include `sess`, and add a PID assertion after the existing `vector`/`decision` checks:
+
+```go
+	sess := &session.Session{ID: "session-test"}
+	sess.SetCurrentProcessPID(4242)
+
+	em := &captureEmitter{}
+	d := &DNSInterceptor{
+		sessionID: "session-test",
+		sess:      sess,
+		pc:        serverPC,
+		upstream:  up.LocalAddr().String(),
+		emit:      em,
+		policy:    engine,
+	}
+```
+
+Add after the existing `decision` assertion (around `:417`):
+
+```go
+	if torEv.PID != 4242 {
+		t.Errorf("event PID = %d, want 4242", torEv.PID)
+	}
+```
+
+Ensure `dns_test.go` imports `"github.com/agentsh/agentsh/internal/session"` (add it to the import block if absent).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/netmonitor/ -run TestDNSInterceptor_OnionEmitsTorControl -count=1`
+Expected: FAIL — `event PID = 0, want 4242` (the interceptor still passes `0`).
+
+- [ ] **Step 3: Read and pass `pid` in `dns.go`**
+
+In `internal/netmonitor/dns.go`, `handle`, extend the `commandID` block (`:96-99`) and the emission (`:124`):
+
+```go
+	commandID := ""
+	pid := 0
+	if d.sess != nil {
+		commandID = d.sess.CurrentCommandID()
+		pid = d.sess.CurrentProcessPID() // command-process PID, not necessarily the leaf caller
+	}
+```
+
+```go
+	if dec.Tor != nil && d.emit != nil {
+		tev := tor.BuildControlEvent(d.sessionID, commandID, pid, tor.Verdict{
+			Vector: dec.Tor.Vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = d.emit.AppendEvent(context.Background(), tev)
+		d.emit.Publish(tev)
+	}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/netmonitor/ -run TestDNSInterceptor -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/netmonitor/dns.go internal/netmonitor/dns_test.go
+git commit -m "feat(tor): onion_dns event carries the command-process PID"
+```
+
+---
+
+### Task 4: onion_http event carries the command PID
+
+**Files:**
+- Modify: `internal/netmonitor/proxy.go` (`handleHTTP`, the `commandID` read `:328-331` and the emission `:397`)
+- Test: `internal/netmonitor/proxy_test.go` (extend `TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP`)
+
+**Interfaces:**
+- Consumes: `session.Session.CurrentProcessPID()`.
+- Produces: nothing new; `onion_http` event now carries `PID`.
+
+- [ ] **Step 1: Extend the existing onion test to set a session PID and assert it**
+
+In `internal/netmonitor/proxy_test.go`, in `TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP`, attach a session with a known PID to the `&Proxy{...}` literal (`:845`) and assert the event PID. Change:
+
+```go
+	sess := &session.Session{ID: "tor-session"}
+	sess.SetCurrentProcessPID(4242)
+
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "tor-session", sess: sess, policy: engine, emit: em}
+```
+
+Add after the existing `vector == "onion_http"` assertion (around `:893`):
+
+```go
+	if torEv.PID != 4242 {
+		t.Fatalf("event PID = %d, want 4242", torEv.PID)
+	}
+```
+
+`proxy_test.go` already imports `session` (it constructs `&session.Session{...}` elsewhere); no import change expected — confirm during implementation.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/netmonitor/ -run TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP -count=1`
+Expected: FAIL — `event PID = 0, want 4242`.
+
+- [ ] **Step 3: Read and pass `pid` in `proxy.go`**
+
+In `internal/netmonitor/proxy.go`, `handleHTTP`, extend the `commandID` block (`:328-331`) and the emission (`:397`):
+
+```go
+	commandID := ""
+	pid := 0
+	if p.sess != nil {
+		commandID = p.sess.CurrentCommandID()
+		pid = p.sess.CurrentProcessPID() // command-process PID, not necessarily the leaf caller
+	}
+```
+
+```go
+	if dec.Tor != nil && p.emit != nil {
+		vector := dec.Tor.Vector
+		if vector == tor.VectorOnionDNS {
+			vector = tor.VectorOnionHTTP
+		}
+		tev := tor.BuildControlEvent(p.sessionID, commandID, pid, tor.Verdict{
+			Vector: vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = p.emit.AppendEvent(context.Background(), tev)
+		p.emit.Publish(tev)
+	}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/netmonitor/ -run TestProxyHandleHTTPOnion -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/netmonitor/proxy.go internal/netmonitor/proxy_test.go
+git commit -m "feat(tor): onion_http event carries the command-process PID"
+```
+
+---
+
+### Task 5: PID-namespace verification + spec status + full gates
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md`
+
+**Interfaces:**
+- Consumes: nothing. Documentation + verification only.
+
+- [ ] **Step 1: Verify the cross-reference claim (read-only)**
+
+Confirm the command-process PID and the ptrace-path PID are in the same (host) PID namespace, so the two event families cross-reference on `pid`:
+- `internal/api/exec.go:357` and `internal/api/exec_stream.go:434` — `SetCurrentProcessPID(cmd.Process.Pid)`; `cmd.Process.Pid` is the host PID of the spawned command (Go `os/exec`).
+- `internal/api/pty_core.go:202` — `SetCurrentProcessPID(ps.PID())`; confirm `ps.PID()` is the host PID of the PTY process.
+- The ptrace-path Tor events use `nc.PID` (`internal/.../ptrace_handlers.go`), the host PID delivered by the ptrace subsystem.
+
+All are host-side PIDs observed by agentsh → the cross-reference holds.
+
+- [ ] **Step 2: Record the finding and flip status in the spec**
+
+In `docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md`, change `**Status:** Draft` to `**Status:** Implemented (PR pending)`, and replace the body of the "PID-namespace checkpoint (verify during implementation)" section with the confirmed result:
+
+```markdown
+## PID-namespace verification (confirmed)
+
+`SetCurrentProcessPID` is called with `cmd.Process.Pid` (`internal/api/exec.go:357`,
+`internal/api/exec_stream.go:434`) and `ps.PID()` (`internal/api/pty_core.go:202`)
+— all host-side PIDs of the command process as agentsh observes it. The
+ptrace-path Tor events use `nc.PID`, also a host-side PID from the ptrace
+subsystem. Both event families therefore carry `pid` in the same namespace and
+cross-reference cleanly.
+```
+
+- [ ] **Step 3: Run the full gates**
+
+```bash
+go build ./...
+GOOS=windows go build ./...
+gofmt -l internal/netmonitor internal/session
+go test ./internal/netmonitor/ ./internal/session/ ./internal/tor/ -count=1
+go test ./...
+```
+
+Expected: builds clean; `gofmt -l` lists none of the files this branch touched (`socks.go`, `transparent_tcp.go`, `dns.go`, `proxy.go`, and the four `*_test.go`); `internal/netmonitor`, `internal/session`, `internal/tor` green. In the full suite, the only acceptable failure is the known pre-existing `internal/fsmonitor` FUSE flake (and, when run alongside `internal/api`, the `internal/ocsf` exhaustiveness flake that passes standalone — this change adds no `events.EventType`). `internal/netmonitor` must be green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md
+git commit -m "docs(tor): mark command-PID attribution implemented; record PID-namespace verification"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- "All four interception-path sites" → Task 1 (socks/onion), Task 2 (relay_ip/socks_port), Task 3 (onion_dns), Task 4 (onion_http). ✅
+- "thread `sess.CurrentProcessPID()`" → Tasks 1–4. ✅
+- "no new event type / config / data path" → Global Constraints; `BuildControlEvent` unchanged. ✅
+- "honest semantics comment at each site" → comments in Tasks 1–4. ✅
+- "idle-session pid 0" → `TestHandleTorSocks_IdleSessionPIDZero` (Task 1), `TestTransparentTCP_TorControlIdlePIDZero` (Task 2). ✅
+- "per-site unit tests" → Tasks 1–4 each add/extend a test. ✅
+- "PID-namespace checkpoint" → Task 5. ✅
+- "reject eBPF leaf attribution" → out of scope; not built. ✅
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**3. Type consistency:** `pid int` appended consistently to `handleTorSocks`/`gatewayConnect`/`gatewayResolve`/`emitOnionEvent`; `emitTorControl(commandID string, pid int, tv *policy.TorVerdict)` matches `dec.Tor`'s type; `CurrentProcessPID()`/`SetCurrentProcessPID(int)` match `internal/session/manager.go`; test PID sentinel `4242` used uniformly. ✅

--- a/docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md
@@ -1,6 +1,6 @@
 # Onion / Connection-Vector Event PID Attribution — Design
 
-**Status:** Draft
+**Status:** Implemented (PR pending)
 
 **Builds on:** [Tor Access Control — Design](2026-06-14-tor-access-control-design.md)
 (Phase 1 deny/audit, PR #424; Phase 2 onion gateway, PR #428), [Phase 3 —
@@ -120,16 +120,14 @@ command), `CurrentProcessPID()` returns 0 and `CurrentCommandID()` returns `""`.
 We emit `pid: 0` honestly in that case — there is no command process to
 attribute — exactly as `commandID` is already empty there. No special-casing.
 
-## PID-namespace checkpoint (verify during implementation)
+## PID-namespace verification (confirmed)
 
-`CurrentProcessPID()` is written by the exec handlers; the ptrace-path events use
-`nc.PID` from the ptrace subsystem. For the two event families to cross-reference
-on `pid`, both must be host-side PIDs in the same namespace. This is near-certain
-(both are PIDs agentsh observes from the host), but the implementation will
-confirm the exec-handler write records the host PID before relying on the
-cross-reference claim. If they were ever to differ, the value is still a correct,
-useful identifier on its own — the checkpoint only governs the cross-reference
-wording, not whether to ship.
+`SetCurrentProcessPID` is called with `cmd.Process.Pid` (`internal/api/exec.go:357`,
+`internal/api/exec_stream.go:434`) and `ps.PID()` (`internal/api/pty_core.go:202`)
+— all host-side PIDs of the command process as agentsh observes it. The
+ptrace-path Tor events use `nc.PID`, also a host-side PID from the ptrace
+subsystem. Both event families therefore carry `pid` in the same namespace and
+cross-reference cleanly.
 
 ## Events / observability
 

--- a/docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md
@@ -1,0 +1,191 @@
+# Onion / Connection-Vector Event PID Attribution — Design
+
+**Status:** Draft
+
+**Builds on:** [Tor Access Control — Design](2026-06-14-tor-access-control-design.md)
+(Phase 1 deny/audit, PR #424; Phase 2 onion gateway, PR #428), [Phase 3 —
+fail-open gap closed](2026-06-20-tor-access-control-phase3-design.md) (PR #429),
+and [Phase 4 — SOCKS RESOLVE](2026-06-22-tor-access-control-phase4-design.md)
+(PR #430). This is the "PID/command attribution" item carried forward as
+out-of-scope by every prior phase.
+
+## Summary
+
+Four `tor_control` events emitted from the transparent-interception layer carry
+`pid: 0`: `onion_dns`, `onion_http`, the Phase-2 `onion` SOCKS gateway, and the
+`relay_ip` / `socks_port` transparent-TCP vector. This change replaces that
+hardcoded zero with the session's current command-process PID, which the session
+already tracks and exposes. It adds **no new event type, config knob, or data
+path** — it passes a value that already exists into a builder parameter that
+already exists.
+
+## Motivation
+
+The framing "these events report `target` only" is pessimistic. Every one of
+these events already carries a correct `sessionID` **and** `commandID` — the
+interceptors read `sess.CurrentCommandID()` at emission time, the same source the
+normal `dns_query` / `net_connect` events use. The single field hardcoded to a
+placeholder is the numeric `pid`:
+
+```go
+tor.BuildControlEvent(d.sessionID, commandID, 0, …)   // dns.go
+```
+
+The ptrace-path Tor events (`ptrace_handlers.go`) carry a real PID because ptrace
+fires synchronously in the offending syscall's context (`nc.PID`). The
+transparent-interception-path events do not, only because the emission sites
+never read the PID the session already holds. Supplying it lets the two event
+families line up on a common `pid` key for cross-referencing.
+
+## Scope decisions (locked)
+
+- **All four interception-path sites, not just the two named.** The backlog item
+  named `onion_dns` / `onion_http`, but the identical `pid: 0` placeholder
+  appears at all four sites below. The fix is the same value at each; leaving two
+  still emitting `pid: 0` would make the audit log inconsistent. Fix all four.
+
+  | Vector | Emission site |
+  |---|---|
+  | `onion_dns` | `internal/netmonitor/dns.go` (`BuildControlEvent(…, 0, …)`) |
+  | `onion_http` | `internal/netmonitor/proxy.go` (`BuildControlEvent(…, 0, …)`) |
+  | `onion` (SOCKS gateway) | `internal/netmonitor/socks.go` (`emitOnionEvent` → `BuildControlEvent(…, 0, …)`) |
+  | `relay_ip` / `socks_port` | `internal/netmonitor/transparent_tcp.go` (`BuildControlEvent(…, 0, …)`) |
+
+- **Mechanism: thread `sess.CurrentProcessPID()`.** The session already exposes
+  `Session.CurrentProcessPID()` (`internal/api/manager.go`), written by the exec
+  handlers when a command process starts, alongside the `CurrentCommandID()` the
+  events already use. The interceptors simply read it and pass it where they
+  currently pass `0`.
+
+- **Rejected: eBPF connect-time PID cross-referencing.** Recovering the *exact
+  leaf* process that emitted the traffic would require a new BPF hash keyed on the
+  connection tuple, populated by the existing `connect()` hooks, cross-referenced
+  synchronously from the interceptor goroutines. It is TCP-only (does not cover
+  the UDP DNS path at all), Linux-only, and substantial new plumbing — over-built
+  for an audit-fidelity improvement. Not in scope.
+
+- **No new config knobs / event type / data path.** `types.Event.PID` and
+  `BuildControlEvent(sessionID, commandID string, pid int, v Verdict)` already
+  exist; the OCSF registry is untouched (consistent with Phases 2–4).
+
+## Architecture: pass the value that already exists
+
+Three of the four sites have the `Session` in scope and call `BuildControlEvent`
+directly — a one-line change each, `0` → `sess.CurrentProcessPID()`:
+
+- `dns.go` — `d.sess.CurrentProcessPID()`
+- `proxy.go` — `p.sess.CurrentProcessPID()`
+- `transparent_tcp.go` — the `relay_ip` / `socks_port` event, `t`-receiver's
+  session (the same `sess` already used for `CurrentCommandID()` at this site).
+
+The SOCKS gateway path is one chain deeper. `emitOnionEvent` is called from
+`gatewayConnect` / `gatewayResolve`, which are invoked by `handleTorSocks`, which
+is called from `transparent_tcp.go` — where the `Session` **is** in scope and
+`commandID` is already read via `CurrentCommandID()`. So read
+`CurrentProcessPID()` at that same call site and thread a `pid int` parameter
+down the existing chain alongside `commandID`:
+
+```
+transparent_tcp.go: pid := sess.CurrentProcessPID()  // next to the existing commandID read
+  → handleTorSocks(…, commandID, pid, …)
+    → gatewayConnect(…, commandID, pid, …) / gatewayResolve(…, commandID, pid, …)
+      → emitOnionEvent(emit, sessionID, commandID, pid, v, socksCmd)
+        → BuildControlEvent(sessionID, commandID, pid, v)
+```
+
+Threading `pid` as a value (not passing the `Session` object) keeps
+`emitOnionEvent` and the gateway handlers pure and value-driven — matching how
+they already take `sessionID` and `commandID` — so the existing in-memory handler
+tests stay simple (they pass a known `pid` and assert it on the event).
+
+`BuildControlEvent` itself is unchanged: it already accepts and stamps `pid`.
+
+## Semantics (stated honestly)
+
+The attributed PID is the **session's current command-process PID** — the root of
+the process tree for the command currently executing in the session. It is **not
+guaranteed to be the exact leaf subprocess** that issued the DNS query, HTTP
+request, or connect: per-process identity is lost when traffic crosses the veth
+into the host-side interceptors, and the originating call may come from any
+descendant of the command process. This is the same basis `commandID` already
+uses, and it is the "which command did this" attribution an auditor wants. Each
+emission site gets a short comment stating this so the approximation is not
+mistaken for precise per-syscall attribution.
+
+## Edge case: idle session
+
+If an interceptor fires while no command is running (rare — the session enforces
+serial command execution, and these interceptors normally fire during an active
+command), `CurrentProcessPID()` returns 0 and `CurrentCommandID()` returns `""`.
+We emit `pid: 0` honestly in that case — there is no command process to
+attribute — exactly as `commandID` is already empty there. No special-casing.
+
+## PID-namespace checkpoint (verify during implementation)
+
+`CurrentProcessPID()` is written by the exec handlers; the ptrace-path events use
+`nc.PID` from the ptrace subsystem. For the two event families to cross-reference
+on `pid`, both must be host-side PIDs in the same namespace. This is near-certain
+(both are PIDs agentsh observes from the host), but the implementation will
+confirm the exec-handler write records the host PID before relying on the
+cross-reference claim. If they were ever to differ, the value is still a correct,
+useful identifier on its own — the checkpoint only governs the cross-reference
+wording, not whether to ship.
+
+## Events / observability
+
+Reuse the existing `tor_control` event. The only change to existing records is
+that `PID` is now populated (non-zero) when a command is running, instead of
+always `0`. `Fields` are unchanged. **No new `events.EventType`** → the OCSF
+registry and its exhaustiveness test are untouched.
+
+## Configuration
+
+**No new config knobs.** PID attribution is automatic wherever these events are
+already emitted. Nothing to opt into or out of.
+
+## Testing
+
+All four sites are unit-testable by driving the interceptor / handler with a
+session (or value) reporting a known command-process PID and asserting the
+emitted `tor_control` event carries it.
+
+1. **SOCKS gateway (`socks.go`)**: extend the existing `assertOnionEvent` helper
+   to assert `ev.PID`; drive `handleTorSocks` (allowed CONNECT and allowed
+   RESOLVE) with a known non-zero `pid` and assert it lands on the emitted event.
+   A denied request likewise stamps the `pid` on its deny event.
+2. **`onion_dns` (`dns.go`)**: a DNS query for a `.onion` with a session stub
+   reporting a known PID emits a `tor_control{vector: onion_dns}` event whose
+   `PID` equals that value.
+3. **`onion_http` (`proxy.go`)**: a proxied request to a `.onion` host with a
+   session stub reporting a known PID emits `tor_control{vector: onion_http}`
+   carrying that `PID`.
+4. **`relay_ip` / `socks_port` (`transparent_tcp.go`)**: the transparent-TCP Tor
+   event carries the session's current PID.
+5. **Idle session**: when the session reports PID 0 / empty command, the event is
+   emitted with `pid: 0` (no panic, no special value).
+
+Where a full interceptor is awkward to stand up in a unit test, test at the
+narrowest seam that still exercises "the session's `CurrentProcessPID()` reaches
+the event" (e.g. a small session interface / stub), rather than booting the whole
+netns data path. The implementation plan will pick the concrete seam per site.
+
+## Non-Goals
+
+- **Exact leaf-subprocess attribution.** The reported PID is the command-process
+  root, not the precise descendant that made the call. Closing that gap needs
+  eBPF tuple→PID cross-referencing (TCP-only, no DNS) — explicitly rejected above.
+- **Per-individual-PID attribution for DNS.** UDP DNS queries cannot be
+  attributed below the session/command granularity given the netns/veth
+  architecture; the command-process PID is the floor.
+- **New config surface, new event type, new data path.** All derive from the
+  existing session state and the existing `tor_control` event.
+- **Changing `commandID` behavior.** Already correct; untouched.
+
+## Out of scope / future (tracked, not built here)
+
+Carried forward from Phase 4, independent of this change:
+
+- **`RESOLVE_PTR` (0xF1) support** — if a concrete consumer appears.
+- **Stream isolation / SOCKS-auth pass-through** — the gateway forces upstream
+  no-auth; per-stream isolation via SOCKS username/password
+  (`IsolateSOCKSAuth`) is unavailable through the gateway.

--- a/internal/netmonitor/dns.go
+++ b/internal/netmonitor/dns.go
@@ -94,8 +94,10 @@ func (d *DNSInterceptor) loop() {
 func (d *DNSInterceptor) handle(clientAddr net.Addr, query []byte) error {
 	domain := parseDNSDomain(query)
 	commandID := ""
+	pid := 0
 	if d.sess != nil {
 		commandID = d.sess.CurrentCommandID()
+		pid = d.sess.CurrentProcessPID() // command-process PID, not necessarily the leaf caller
 	}
 
 	// Use timeout context for DNS handling
@@ -121,7 +123,7 @@ func (d *DNSInterceptor) handle(clientAddr net.Addr, query []byte) error {
 	dec = d.maybeApprove(ctx, commandID, dec, "dns", domain)
 
 	if dec.Tor != nil && d.emit != nil {
-		tev := tor.BuildControlEvent(d.sessionID, commandID, 0, tor.Verdict{
+		tev := tor.BuildControlEvent(d.sessionID, commandID, pid, tor.Verdict{
 			Vector: dec.Tor.Vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
 		})
 		_ = d.emit.AppendEvent(context.Background(), tev)

--- a/internal/netmonitor/dns.go
+++ b/internal/netmonitor/dns.go
@@ -354,9 +354,9 @@ func buildDNSRedirectResponse(query []byte, ip net.IP) []byte {
 	binary.BigEndian.PutUint16(resp[2:4], flags)
 
 	// Set counts: QDCOUNT=1, ANCOUNT=1, NSCOUNT=0, ARCOUNT=0
-	binary.BigEndian.PutUint16(resp[4:6], 1)  // QDCOUNT
-	binary.BigEndian.PutUint16(resp[6:8], 1)  // ANCOUNT
-	binary.BigEndian.PutUint16(resp[8:10], 0) // NSCOUNT
+	binary.BigEndian.PutUint16(resp[4:6], 1)   // QDCOUNT
+	binary.BigEndian.PutUint16(resp[6:8], 1)   // ANCOUNT
+	binary.BigEndian.PutUint16(resp[8:10], 0)  // NSCOUNT
 	binary.BigEndian.PutUint16(resp[10:12], 0) // ARCOUNT
 
 	// Build answer section

--- a/internal/netmonitor/dns_test.go
+++ b/internal/netmonitor/dns_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
@@ -389,9 +390,13 @@ func TestDNSInterceptor_OnionEmitsTorControl(t *testing.T) {
 	}
 	engine.SetTorPolicy(stubTorChecker{})
 
+	sess := &session.Session{ID: "session-test"}
+	sess.SetCurrentProcessPID(4242)
+
 	em := &captureEmitter{}
 	d := &DNSInterceptor{
 		sessionID: "session-test",
+		sess:      sess,
 		pc:        serverPC,
 		upstream:  up.LocalAddr().String(),
 		emit:      em,
@@ -419,5 +424,8 @@ func TestDNSInterceptor_OnionEmitsTorControl(t *testing.T) {
 	}
 	if got := torEv.Fields["target"]; got != "abcdefghij.onion" {
 		t.Errorf("expected target abcdefghij.onion, got %v", got)
+	}
+	if torEv.PID != 4242 {
+		t.Errorf("event PID = %d, want 4242", torEv.PID)
 	}
 }

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -326,8 +326,10 @@ func (p *Proxy) handleHTTP(client net.Conn, req *http.Request) error {
 	}
 
 	commandID := ""
+	pid := 0
 	if p.sess != nil {
 		commandID = p.sess.CurrentCommandID()
+		pid = p.sess.CurrentProcessPID() // command-process PID, not necessarily the leaf caller
 	}
 	engine := p.policyEngine()
 
@@ -394,7 +396,7 @@ func (p *Proxy) handleHTTP(client net.Conn, req *http.Request) error {
 		if vector == tor.VectorOnionDNS {
 			vector = tor.VectorOnionHTTP
 		}
-		tev := tor.BuildControlEvent(p.sessionID, commandID, 0, tor.Verdict{
+		tev := tor.BuildControlEvent(p.sessionID, commandID, pid, tor.Verdict{
 			Vector: vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
 		})
 		_ = p.emit.AppendEvent(context.Background(), tev)

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -841,8 +841,11 @@ func TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP(t *testing.T) {
 	}
 	engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
 
+	sess := &session.Session{ID: "tor-session"}
+	sess.SetCurrentProcessPID(4242)
+
 	em := &stubEmitter{}
-	p := &Proxy{sessionID: "tor-session", policy: engine, emit: em}
+	p := &Proxy{sessionID: "tor-session", sess: sess, policy: engine, emit: em}
 
 	// EvalOnionName matches any .onion suffix; use a syntactically valid
 	// v3-style onion host.
@@ -890,6 +893,9 @@ func TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP(t *testing.T) {
 	}
 	if got := torEv.Fields["vector"]; got != "onion_http" {
 		t.Fatalf("vector = %v, want onion_http (the handleHTTP remap from onion_dns)", got)
+	}
+	if torEv.PID != 4242 {
+		t.Fatalf("event PID = %d, want 4242", torEv.PID)
 	}
 	if got := torEv.Fields["decision"]; got != "deny" {
 		t.Fatalf("decision = %v, want deny", got)

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -137,7 +137,7 @@ type TorGatewayPolicy interface {
 // dispatches on the command: CONNECT tunnels through the onion gateway,
 // RESOLVE is filtered-and-forwarded, and every other command is rejected with
 // command-not-supported. Fail-closed on any error.
-func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string) error {
+func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int) error {
 	defer conn.Close()
 
 	if err := readSocksGreeting(conn); err != nil {
@@ -154,9 +154,9 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 
 	switch req.cmd {
 	case socksCmdConnect:
-		return gatewayConnect(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
+		return gatewayConnect(conn, upstreamAddr, pol, emit, sessionID, commandID, pid, req)
 	case socksCmdResolve:
-		return gatewayResolve(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
+		return gatewayResolve(conn, upstreamAddr, pol, emit, sessionID, commandID, pid, req)
 	default:
 		// RESOLVE_PTR (0xF1), BIND, UDP ASSOCIATE, etc. — deliberately
 		// unsupported. Reply the correct SOCKS code and close; no event,
@@ -170,10 +170,10 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 // gateway policy, and either proxy the stream to the real Tor SOCKS daemon or
 // reply not-allowed. Fail-closed on any error. Emits one tor_control{vector:
 // onion, socks_cmd: connect} event.
-func gatewayConnect(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, req socksReq) error {
+func gatewayConnect(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int, req socksReq) error {
 	v, ok := pol.EvalSocksTarget(req.host, req.port)
 	if ok {
-		emitOnionEvent(emit, sessionID, commandID, v, "connect")
+		emitOnionEvent(emit, sessionID, commandID, pid, v, "connect")
 	}
 	if !ok || v.Decision != "allow" {
 		_ = writeSocksReply(conn, socksRepNotAllowed)
@@ -298,10 +298,10 @@ func halfCloseWrite(c net.Conn) {
 // the upstream Tor daemon and relays its single reply verbatim. RESOLVE is a
 // request/reply exchange, not a tunnel — there is no splice. Emits one
 // tor_control{vector: onion, socks_cmd: resolve} event.
-func gatewayResolve(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, req socksReq) error {
+func gatewayResolve(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, pid int, req socksReq) error {
 	v, ok := pol.EvalSocksTarget(req.host, req.port)
 	if ok {
-		emitOnionEvent(emit, sessionID, commandID, v, "resolve")
+		emitOnionEvent(emit, sessionID, commandID, pid, v, "resolve")
 	}
 	if !ok || v.Decision != "allow" {
 		_ = writeSocksReply(conn, socksRepNotAllowed)
@@ -334,11 +334,13 @@ func gatewayResolve(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	return err
 }
 
-func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict, socksCmd string) {
+func emitOnionEvent(emit Emitter, sessionID, commandID string, pid int, v tor.Verdict, socksCmd string) {
 	if emit == nil {
 		return
 	}
-	ev := tor.BuildControlEvent(sessionID, commandID, 0, v)
+	// pid is the session's current command-process PID (root of the running
+	// command's process tree), not necessarily the exact leaf caller.
+	ev := tor.BuildControlEvent(sessionID, commandID, pid, v)
 	ev.Fields["socks_cmd"] = socksCmd
 	_ = emit.AppendEvent(context.Background(), ev)
 	emit.Publish(ev)

--- a/internal/netmonitor/socks_handler_test.go
+++ b/internal/netmonitor/socks_handler_test.go
@@ -82,8 +82,8 @@ func fakeTorUpstreamWithReply(t *testing.T, rep byte) (addr string, stop func())
 }
 
 // assertOnionEvent waits for one tor_control{vector:onion} event and asserts
-// both its decision and its socks_cmd field.
-func assertOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision, wantCmd string) {
+// its decision, socks_cmd field, and PID.
+func assertOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision, wantCmd string, wantPID int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -94,6 +94,9 @@ func assertOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision, wantC
 				}
 				if ev.Fields["socks_cmd"] != wantCmd {
 					t.Fatalf("event socks_cmd = %v, want %v", ev.Fields["socks_cmd"], wantCmd)
+				}
+				if ev.PID != wantPID {
+					t.Fatalf("event PID = %d, want %d", ev.PID, wantPID)
 				}
 				return
 			}
@@ -144,7 +147,7 @@ func TestHandleTorSocks_Allowed(t *testing.T) {
 	client, server := net.Pipe()
 	emit := &torCaptureEmitter{}
 	go func() {
-		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 
 	rep := driveClient(t, client, "ok.onion", 443)
@@ -163,7 +166,7 @@ func TestHandleTorSocks_Allowed(t *testing.T) {
 	}
 	client.Close()
 
-	assertOnionEvent(t, emit, "allow", "connect")
+	assertOnionEvent(t, emit, "allow", "connect", 4242)
 }
 
 func TestHandleTorSocks_Denied(t *testing.T) {
@@ -173,7 +176,7 @@ func TestHandleTorSocks_Denied(t *testing.T) {
 	client, server := net.Pipe()
 	emit := &torCaptureEmitter{}
 	go func() {
-		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 
 	rep := driveClient(t, client, "blocked.onion", 443)
@@ -181,7 +184,7 @@ func TestHandleTorSocks_Denied(t *testing.T) {
 		t.Fatalf("denied target got reply 0x%02x, want not-allowed", rep)
 	}
 	client.Close()
-	assertOnionEvent(t, emit, "deny", "connect")
+	assertOnionEvent(t, emit, "deny", "connect", 4242)
 }
 
 // TestHandleTorSocks_UpstreamRefuses verifies that when the upstream Tor daemon
@@ -197,7 +200,7 @@ func TestHandleTorSocks_UpstreamRefuses(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 
 	// Drive client: should receive the upstream's non-success reply.
@@ -217,7 +220,7 @@ func TestHandleTorSocks_UpstreamRefuses(t *testing.T) {
 	}
 
 	// The allow event should still have been emitted for the allowed target.
-	assertOnionEvent(t, emit, "allow", "connect")
+	assertOnionEvent(t, emit, "allow", "connect", 4242)
 }
 
 // fakeTorUpstreamRequiresAuth is a fake upstream that rejects the method
@@ -260,7 +263,7 @@ func TestHandleTorSocks_UpstreamRequiresAuth(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 
 	// The client must get a general-failure reply — not a success, not a hang.
@@ -279,7 +282,7 @@ func TestHandleTorSocks_UpstreamRequiresAuth(t *testing.T) {
 
 	// Policy is evaluated (and the onion event emitted) before the upstream
 	// auth failure, so an allow event is still recorded.
-	assertOnionEvent(t, emit, "allow", "connect")
+	assertOnionEvent(t, emit, "allow", "connect", 4242)
 }
 
 // TestHandleTorSocks_UnsupportedCommand verifies a non-CONNECT/non-RESOLVE
@@ -292,7 +295,7 @@ func TestHandleTorSocks_UnsupportedCommand(t *testing.T) {
 	go func() {
 		defer close(done)
 		// upstreamAddr is unreachable on purpose; it must never be dialed.
-		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 	rep := driveCmd(t, client, 0x02 /* BIND */, "ok.onion", 443)
 	if rep != socksRepCmdNotSupported {
@@ -473,7 +476,7 @@ func TestHandleTorSocks_ResolveAllowed(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 
 	reply := driveResolve(t, client, "ok.onion")
@@ -489,7 +492,7 @@ func TestHandleTorSocks_ResolveAllowed(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("handleTorSocks did not return after RESOLVE (possible spurious splice)")
 	}
-	assertOnionEvent(t, emit, "allow", "resolve")
+	assertOnionEvent(t, emit, "allow", "resolve", 4242)
 }
 
 // TestHandleTorSocks_ResolveDenied verifies a denied RESOLVE replies not-allowed
@@ -499,14 +502,14 @@ func TestHandleTorSocks_ResolveDenied(t *testing.T) {
 	emit := &torCaptureEmitter{}
 	go func() {
 		// upstreamAddr unreachable on purpose; a denied RESOLVE must not dial.
-		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 	reply := driveResolve(t, client, "blocked.onion")
 	if reply[1] != socksRepNotAllowed {
 		t.Fatalf("denied RESOLVE reply REP = 0x%02x, want not-allowed", reply[1])
 	}
 	client.Close()
-	assertOnionEvent(t, emit, "deny", "resolve")
+	assertOnionEvent(t, emit, "deny", "resolve", 4242)
 }
 
 // TestHandleTorSocks_ResolveUpstreamError verifies a non-success RESOLVE reply
@@ -521,7 +524,7 @@ func TestHandleTorSocks_ResolveUpstreamError(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1", 4242)
 	}()
 	reply := driveResolve(t, client, "ok.onion")
 	if reply[1] != 0x04 {
@@ -533,5 +536,20 @@ func TestHandleTorSocks_ResolveUpstreamError(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("handleTorSocks did not return after RESOLVE upstream error")
 	}
-	assertOnionEvent(t, emit, "allow", "resolve")
+	assertOnionEvent(t, emit, "allow", "resolve", 4242)
+}
+
+func TestHandleTorSocks_IdleSessionPIDZero(t *testing.T) {
+	upstream, stop := fakeTorUpstream(t)
+	defer stop()
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	go func() {
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "", 0)
+	}()
+	if rep := driveClient(t, client, "ok.onion", 443); rep != 0x00 {
+		t.Fatalf("rep = 0x%02x, want 0x00", rep)
+	}
+	assertOnionEvent(t, emit, "allow", "connect", 0)
+	client.Close()
 }

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -110,13 +110,15 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 	remote := net.JoinHostPort(dstIP.String(), fmt.Sprintf("%d", dstPort))
 
 	commandID := ""
+	pid := 0
 	if t.sess != nil {
 		commandID = t.sess.CurrentCommandID()
+		pid = t.sess.CurrentProcessPID() // command-process PID; reused by the relay_ip/socks_port emit below
 	}
 	engine := t.policyEngine()
 
 	if cfg, ok := t.torGatewayFor(dstPort); ok {
-		return handleTorSocks(conn, cfg.upstream, cfg.pol, t.emit, t.sessionID, commandID)
+		return handleTorSocks(conn, cfg.upstream, cfg.pol, t.emit, t.sessionID, commandID, pid)
 	}
 
 	domain := dstIP.String()

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -141,13 +141,7 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 	}
 
 	dec := t.checkConnectNetwork(context.Background(), commandID, domain, redirectHostPort, dstIP, dstPort, redirectResult)
-	if dec.Tor != nil && t.emit != nil {
-		tev := tor.BuildControlEvent(t.sessionID, commandID, 0, tor.Verdict{
-			Vector: dec.Tor.Vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
-		})
-		_ = t.emit.AppendEvent(context.Background(), tev)
-		t.emit.Publish(tev)
-	}
+	t.emitTorControl(commandID, pid, dec.Tor)
 	eventFields := map[string]any{}
 	if redirectResult != nil {
 		if redirectResult.RedirectTo != "" {
@@ -238,6 +232,20 @@ func (t *TransparentTCP) emitDBBypassAttempt(ctx context.Context, commandID stri
 		RuleName:        ruleName,
 		Reason:          reason,
 	})
+}
+
+// emitTorControl publishes a tor_control event for a Tor verdict carried on a
+// connect decision. pid is the session's current command-process PID (root of
+// the running command's process tree), not necessarily the exact leaf caller.
+func (t *TransparentTCP) emitTorControl(commandID string, pid int, tv *policy.TorVerdict) {
+	if tv == nil || t.emit == nil {
+		return
+	}
+	tev := tor.BuildControlEvent(t.sessionID, commandID, pid, tor.Verdict{
+		Vector: tv.Vector, Mode: tv.Mode, Decision: tv.Decision, Target: tv.Target,
+	})
+	_ = t.emit.AppendEvent(context.Background(), tev)
+	t.emit.Publish(tev)
 }
 
 func (t *TransparentTCP) maybeApprove(ctx context.Context, commandID string, dec policy.Decision, kind string, target string) policy.Decision {

--- a/internal/netmonitor/transparent_tcp_test.go
+++ b/internal/netmonitor/transparent_tcp_test.go
@@ -186,6 +186,41 @@ func TestTransparentTCPUsesSessionPolicyEngineForNetworkChecks(t *testing.T) {
 	}
 }
 
+func TestTransparentTCP_TorControlCarriesCommandPID(t *testing.T) {
+	em := &captureEmitter{}
+	tcp := &TransparentTCP{sessionID: "s", emit: em}
+	tcp.emitTorControl("cmd-1", 4242, &policy.TorVerdict{
+		Vector: "relay_ip", Mode: "deny", Decision: "deny", Target: "10.0.0.1:443",
+	})
+	if len(em.events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(em.events))
+	}
+	ev := em.events[0]
+	if ev.Type != "tor_control" {
+		t.Fatalf("type = %q, want tor_control", ev.Type)
+	}
+	if ev.PID != 4242 {
+		t.Fatalf("PID = %d, want 4242", ev.PID)
+	}
+	if ev.Fields["vector"] != "relay_ip" {
+		t.Fatalf("vector = %v, want relay_ip", ev.Fields["vector"])
+	}
+}
+
+func TestTransparentTCP_TorControlIdlePIDZero(t *testing.T) {
+	em := &captureEmitter{}
+	tcp := &TransparentTCP{sessionID: "s", emit: em}
+	tcp.emitTorControl("", 0, &policy.TorVerdict{
+		Vector: "socks_port", Mode: "deny", Decision: "deny", Target: "127.0.0.1:9050",
+	})
+	if len(em.events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(em.events))
+	}
+	if em.events[0].PID != 0 {
+		t.Fatalf("PID = %d, want 0", em.events[0].PID)
+	}
+}
+
 func newTransparentDBRedirectEngine(t *testing.T, includeRedirectMetadata bool) *policy.Engine {
 	t.Helper()
 


### PR DESCRIPTION
## Command-PID attribution for interception-path `tor_control` events

The four `tor_control` audit events emitted from the transparent-interception layer carried `pid: 0`: `onion_dns`, `onion_http`, the Phase-2 `onion` SOCKS gateway, and the `relay_ip` / `socks_port` transparent-TCP vector. They already carried a correct `sessionID` and `commandID` — only the numeric `pid` was a hardcoded placeholder, because the interceptors never read the PID the session already tracks. The ptrace-path Tor events, by contrast, carry a real PID (`nc.PID`). This change lines all of them up on a common `pid` key.

Each interception point now reads `sess.CurrentProcessPID()` (next to the `commandID` it already reads) and passes it where it previously passed `0`:

- **`onion_dns`** (`dns.go`), **`onion_http`** (`proxy.go`), **`relay_ip`/`socks_port`** (`transparent_tcp.go`) — one-line `pid` read inside the existing `sess != nil` guard. The transparent-TCP emission was extracted into a small behavior-preserving `emitTorControl` method (also gives it a root-free unit-test seam).
- **`onion` SOCKS gateway** (`socks.go`) — a `pid int` value threaded through `handleTorSocks → gatewayConnect/gatewayResolve → emitOnionEvent`.

### Semantics (honest)

The value is the session's **current command-process PID** — the root of the running command's process tree, not necessarily the exact leaf subprocess that issued the call (per-process identity is lost crossing the veth into the host interceptors). That is the same basis `commandID` already uses, and the "which command did this" answer an auditor wants. A comment at each site says so. An idle session (no command running) honestly emits `pid: 0`.

A PID-namespace check confirms `CurrentProcessPID()` (set from `cmd.Process.Pid` / `ps.PID()`) and the ptrace path's `nc.PID` are both host-side PIDs, so the two event families cross-reference cleanly.

### Properties

- **No new event type** — reuses `tor_control`; the OCSF registry is untouched. `tor.BuildControlEvent`'s signature is unchanged (`pid` was always a parameter).
- **No new config knob, no new data path.** Behavior derives entirely from existing session state.
- **Rejected as over-engineering:** eBPF connect-time tuple→PID cross-referencing for exact leaf attribution (TCP-only, no DNS coverage).

### Testing

Per-site unit tests assert the emitted event carries the session's PID (`4242`), plus idle-session (`pid: 0`) cases for the SOCKS and transparent-TCP paths. `go build ./...` + `GOOS=windows go build ./...` clean; `internal/netmonitor`, `internal/session`, `internal/tor` green.

Design: `docs/superpowers/specs/2026-06-22-onion-event-pid-attribution-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
