### PR TITLE
fix(ci): pin rockylinux10 test image to dl.rockylinux.org baseurl (mirrorlist outage)

### DIFF
--- a/Dockerfile.test.rockylinux10
+++ b/Dockerfile.test.rockylinux10
@@ -18,7 +18,15 @@ ARG AGENTSH_REPO=canyonroad/agentsh
 ARG AGENTSH_TAG=v0.10.1
 
 # Install dependencies: curl for downloading, bash for shim tests, jq for JSON parsing.
+#
+# Rocky's default repos resolve packages via mirrors.rockylinux.org/mirrorlist,
+# which intermittently returns an empty list ("Cannot prepare internal
+# mirrorlist: No URLs in mirrorlist") and breaks `dnf install` in CI with no
+# bearing on what we're testing. Pin to Rocky's canonical content CDN
+# (dl.rockylinux.org) by switching the repo files from mirrorlist= to the
+# shipped baseurl=, exactly as the repo file's own comment recommends.
 RUN set -eux; \
+  sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=|baseurl=|g' /etc/yum.repos.d/*.repo; \
   dnf install -y curl bash jq libseccomp; \
   dnf clean all
 


### PR DESCRIPTION
## Pin the Rocky Linux 10 test image to `dl.rockylinux.org` (mirrorlist outage)

The `docker-test (rockylinux10)` leg of the release workflow failed during the **v0.20.5** release build:

```
Error: Failed to download metadata for repo 'baseos':
Cannot prepare internal mirrorlist: No URLs in mirrorlist
```

Rocky's default repo files resolve packages via `mirrors.rockylinux.org/mirrorlist`, which intermittently returns an empty list. When that happens, `dnf install` fails and the leg goes red — with no bearing on what the test validates. (The v0.20.5 release itself published fine; only this post-publish test leg was affected. `v0.20.5-rc1`, cut ~25 min earlier, was all-green because the mirror was up then.)

### Fix

Switch the repo files from `mirrorlist=` to Rocky's shipped `baseurl=` (`dl.rockylinux.org`, the canonical content CDN) before `dnf install` — exactly what the repo file's own comment recommends ("If the mirrorlist does not work for you, you can try the commented out baseurl line instead"):

```dockerfile
RUN set -eux; \
  sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=|baseurl=|g' /etc/yum.repos.d/*.repo; \
  dnf install -y curl bash jq libseccomp; \
  dnf clean all
```

The `baseurl` uses Rocky's `$contentdir/$releasever/$basearch` macros, so it stays arch- and release-correct.

### Verification

This Dockerfile is exercised only by `release.yml` (on tags), not by PR CI — so it was verified **locally**:

- `docker build -f Dockerfile.test.rockylinux10 --build-arg AGENTSH_TAG=v0.20.5 …` → `dnf install` now succeeds via `dl.rockylinux.org`; full image builds clean (RPM install + shim install).
- `docker run` of the built image → integration test **48 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
