### PR TITLE
fix(ebpf): decode connect events from BPF layout

### DIFF
--- a/internal/netmonitor/ebpf/collector.go
+++ b/internal/netmonitor/ebpf/collector.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 )
 
-// ConnectEvent matches the struct emitted by the BPF program.
+// ConnectEvent is the decoded representation of connect_event from connect.bpf.c.
 type ConnectEvent struct {
 	TsNs     uint64
 	Cookie   uint64
@@ -32,6 +32,14 @@ type ConnectEvent struct {
 	Blocked  uint8
 	_pad     [7]byte
 }
+
+const (
+	connectEventBaseLen       = 30
+	connectEventDstOffset     = 36
+	connectEventDstEndOffset  = connectEventDstOffset + 16
+	connectEventBlockedOffset = connectEventDstEndOffset
+	connectEventMinLen        = connectEventBlockedOffset + 1
+)
 
 // Collector reads events from the BPF ring buffer.
 type Collector struct {
@@ -91,7 +99,7 @@ func (c *Collector) loop() {
 			continue
 		}
 		var ev ConnectEvent
-		if len(record.RawSample) >= 49 { // 49 bytes needed for blocked flag
+		if len(record.RawSample) >= connectEventMinLen {
 			copyToEvent(&ev, record.RawSample)
 
 			// Evaluate connect redirect if configured
@@ -111,7 +119,7 @@ func (c *Collector) loop() {
 func copyToEvent(ev *ConnectEvent, data []byte) {
 	// Layout matches struct in connect.bpf.c
 	// Minimum 30 bytes required for base fields (up to Protocol at offset 29)
-	if len(data) < 30 {
+	if len(data) < connectEventBaseLen {
 		return
 	}
 	ev.TsNs = le64(data[0:])
@@ -122,14 +130,14 @@ func copyToEvent(ev *ConnectEvent, data []byte) {
 	ev.Dport = le16(data[26:])
 	ev.Family = data[28]
 	ev.Protocol = data[29]
-	if len(data) >= 48 {
-		copy(ev.DstIPv6[:], data[32:48]) // always copy 16 bytes
-		if len(data) >= 40 {
-			ev.DstIPv4 = le32(data[36:]) // overlap ok for v4
-		}
+	if len(data) >= connectEventDstOffset+4 {
+		ev.DstIPv4 = le32(data[connectEventDstOffset:])
 	}
-	if len(data) > 48 {
-		ev.Blocked = data[48]
+	if len(data) >= connectEventDstEndOffset {
+		copy(ev.DstIPv6[:], data[connectEventDstOffset:connectEventDstEndOffset])
+	}
+	if len(data) > connectEventBlockedOffset {
+		ev.Blocked = data[connectEventBlockedOffset]
 	}
 }
 

--- a/internal/netmonitor/ebpf/collector_test.go
+++ b/internal/netmonitor/ebpf/collector_test.go
@@ -18,10 +18,67 @@ func TestCopyToEventBounds(t *testing.T) {
 	copyToEvent(&ev, data)
 }
 
+func TestCopyToEventDecodesBlockedFlagFromConnectEventLayout(t *testing.T) {
+	var ev ConnectEvent
+	data := make([]byte, 60)
+	data[48] = 0
+	data[connectEventBlockedOffset] = 1
+
+	copyToEvent(&ev, data)
+
+	if ev.Blocked != 1 {
+		t.Fatalf("Blocked = %d, want 1", ev.Blocked)
+	}
+}
+
+func TestCopyToEventDecodesIPv4DestinationFromConnectEventLayout(t *testing.T) {
+	var ev ConnectEvent
+	data := make([]byte, 60)
+	data[connectEventDstOffset+0] = 127
+	data[connectEventDstOffset+1] = 0
+	data[connectEventDstOffset+2] = 0
+	data[connectEventDstOffset+3] = 1
+
+	copyToEvent(&ev, data)
+
+	if got, want := ev.DstIPv4, uint32(0x0100007f); got != want {
+		t.Fatalf("DstIPv4 = %#x, want %#x", got, want)
+	}
+}
+
+func TestCopyToEventDecodesIPv6DestinationFromConnectEventLayout(t *testing.T) {
+	var ev ConnectEvent
+	data := make([]byte, 60)
+	want := net.ParseIP("2001:db8::1").To16()
+	if want == nil {
+		t.Fatal("failed to parse test IPv6 address")
+	}
+	copy(data[connectEventDstOffset:connectEventDstEndOffset], want)
+
+	copyToEvent(&ev, data)
+
+	got := net.IP(ev.DstIPv6[:])
+	if !got.Equal(want) {
+		t.Fatalf("DstIPv6 = %v, want %v", got, want)
+	}
+}
+
+func TestCopyToEventIgnoresOldBlockedOffset(t *testing.T) {
+	var ev ConnectEvent
+	data := make([]byte, connectEventBlockedOffset)
+	data[48] = 1
+
+	copyToEvent(&ev, data)
+
+	if ev.Blocked != 0 {
+		t.Fatalf("Blocked = %d, want 0", ev.Blocked)
+	}
+}
+
 func TestExtractDstIP_IPv4(t *testing.T) {
 	c := &Collector{}
 	ev := &ConnectEvent{
-		Family:  2, // AF_INET
+		Family:  2,          // AF_INET
 		DstIPv4: 0x0100007f, // 127.0.0.1 in little-endian
 	}
 


### PR DESCRIPTION
## Summary

Fixes userspace decoding of eBPF `connect_event` samples to match the layout emitted by `connect.bpf.c`.

The BPF event has six bytes of padding before the destination union, so the destination starts at offset 36 and the `blocked` flag is at offset 52. The previous decoder copied IPv6 destinations from offset 32 and read `blocked` from offset 48.

## Fix

* Decode IPv4 from offset 36.
* Decode IPv6 from offset 36 through 52.
* Decode the `blocked` flag from offset 52.
* Require enough raw sample bytes before forwarding a full connect event.
* Clarify that `ConnectEvent` is the decoded representation of the BPF event.
* Add focused tests that prove the old offsets are not used.

## Validation

* `go test ./internal/netmonitor/ebpf -run 'TestCopyToEvent' -count=1`
* `go test ./internal/netmonitor/ebpf/... -count=1`
