### PR TITLE
fix(daemon): daemon install --force leaves the old service definition running (#439)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-daemon-install-reload.md
+++ b/docs/superpowers/plans/2026-08-05-daemon-install-reload.md
@@ -1,0 +1,545 @@
+# `daemon install --force` Service Reload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agentsh daemon install --force` actually apply the new service definition — unload/reload on macOS, restart-if-active on Linux — and fail loudly instead of warning when the service can't be (re)loaded. Fixes [#439](https://github.com/canyonroad/agentsh/issues/439).
+
+**Architecture:** All changes live in `internal/cli/daemon.go`: two new helpers (`reloadLaunchdService`, `restartSystemdIfActive`) shared by the install/restart call sites, plus unifying home-dir resolution on the existing `userHomeDir()` helper so tests can sandbox with `$HOME`. Tests use fake `launchctl`/`systemctl` shell scripts on a prepended `PATH` (house style — see `internal/cli/auto_daemon_test.go`).
+
+**Tech Stack:** Go, cobra, stdlib testing. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md` — read it before starting.
+
+**Branch:** work happens on `fix/439-daemon-install-reload` (already exists, contains the spec).
+
+---
+
+## File Structure
+
+- Modify: `internal/cli/daemon.go` — helpers + call-site changes (only file with production changes)
+- Create: `internal/cli/daemon_install_test.go` — fake-tool test helpers + all new tests (kept out of the already-385-line `daemon_test.go`)
+
+---
+
+### Task 1: Unify home-directory resolution on `userHomeDir()`
+
+**Why no failing test first:** running the install functions under a redirected `$HOME` *before* this change writes real files into the developer's `~/Library/LaunchAgents` / `~/.config/systemd/user` (with cgo, `user.Current()` ignores `$HOME`). The spec reviewer flagged exactly this hazard. This task is a mechanical refactor with no behavior change on normal systems; every test added in Tasks 2–3 exercises it (they all assert files land inside the sandbox `$HOME`).
+
+**Files:**
+- Modify: `internal/cli/daemon.go` (functions `installSystemdService`, `uninstallSystemdService`, `installLaunchdService`)
+
+- [ ] **Step 1: Switch `installSystemdService` to `userHomeDir()`**
+
+Keep the `user.Current()` block — `currentUser.Uid` is still needed for the `XDG_RUNTIME_DIR=/run/user/%s` template value. Add `home := userHomeDir()` right after it, then replace the three `currentUser.HomeDir` uses:
+
+```go
+	// Get user info
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %w", err)
+	}
+	home := userHomeDir()
+```
+
+```go
+	systemdDir := filepath.Join(home, ".config", "systemd", "user")
+```
+
+```go
+	dataDir := filepath.Join(home, ".local", "share", "agentsh")
+```
+
+```go
+	serviceContent := fmt.Sprintf(systemdServiceTemplate,
+		exePath,
+		home,
+		currentUser.Uid,
+		dataDir,
+	)
+```
+
+- [ ] **Step 2: Switch `uninstallSystemdService` to `userHomeDir()`**
+
+Install now derives the unit path from `userHomeDir()`; uninstall must resolve the identical path or it could miss the file. The `user.Current()` call drops out of this function entirely:
+
+```go
+func uninstallSystemdService(cmd *cobra.Command) error {
+	w := cmd.OutOrStdout()
+
+	servicePath := filepath.Join(userHomeDir(), ".config", "systemd", "user", "agentsh.service")
+```
+
+(The rest of the function is unchanged.)
+
+- [ ] **Step 3: Switch `installLaunchdService` to `userHomeDir()`**
+
+`user.Current()` drops out of this function entirely (it was only used for `HomeDir`). This also makes the LaunchAgents dir agree with `getLaunchdPlistPath()`, which already uses `os.UserHomeDir()`:
+
+```go
+func installLaunchdService(cmd *cobra.Command, force bool) error {
+	w := cmd.OutOrStdout()
+
+	home := userHomeDir()
+
+	exePath, err := os.Executable()
+```
+
+```go
+	launchAgentsDir := filepath.Join(home, "Library", "LaunchAgents")
+```
+
+```go
+	logDir := filepath.Join(home, "Library", "Logs", "agentsh")
+```
+
+```go
+	plistContent := fmt.Sprintf(launchdPlistTemplate,
+		exePath,
+		logDir,
+		logDir,
+		home,
+	)
+```
+
+- [ ] **Step 4: Verify build and existing tests**
+
+Run: `go build ./... && go test ./internal/cli/`
+Expected: build succeeds, all existing tests PASS (`os/user` must still be imported — `installSystemdService` and `getCurrentSession` use it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/daemon.go
+git commit -m "refactor(daemon): resolve service paths via userHomeDir() consistently
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: macOS — reload the service on install, hard-error on load failure
+
+**Files:**
+- Modify: `internal/cli/daemon.go` (add `reloadLaunchdService`; change `installLaunchdService` load block and `newDaemonRestartCmd` darwin branch)
+- Create: `internal/cli/daemon_install_test.go`
+
+- [ ] **Step 1: Create the test file with fake-tool helpers and the macOS tests**
+
+Create `internal/cli/daemon_install_test.go`:
+
+```go
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// setupFakeTools installs fake launchctl/systemctl executables on PATH that
+// append each invocation to a calls file, and redirects HOME to a temp dir so
+// service files land in the test sandbox. The body script runs after the call
+// is recorded and controls the fake's behavior; an empty body means exit 0.
+func setupFakeTools(t *testing.T, launchctlBody, systemctlBody string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-tool tests require /bin/sh")
+	}
+	binDir := t.TempDir()
+	callsFile := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("AGENTSH_TEST_CALLS", callsFile)
+	writeTool := func(name, body string) {
+		script := "#!/bin/sh\n" +
+			"echo \"$(basename \"$0\") $@\" >> \"$AGENTSH_TEST_CALLS\"\n" +
+			body + "\nexit 0\n"
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	writeTool("launchctl", launchctlBody)
+	writeTool("systemctl", systemctlBody)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", t.TempDir())
+	return callsFile
+}
+
+// recordedCalls returns the fake-tool invocations, one per line, or nil if no
+// tool was ever called.
+func recordedCalls(t *testing.T, callsFile string) []string {
+	t.Helper()
+	data, err := os.ReadFile(callsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read calls file: %v", err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func newTestCmd() (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	return cmd, buf
+}
+
+func assertCalls(t *testing.T, got, want []string) {
+	t.Helper()
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("recorded calls:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestInstallLaunchd_UnloadsBeforeLoad(t *testing.T) {
+	callsFile := setupFakeTools(t, "", "")
+	cmd, buf := newTestCmd()
+
+	if err := installLaunchdService(cmd, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	plistPath := getLaunchdPlistPath()
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"launchctl unload " + plistPath,
+		"launchctl load " + plistPath,
+	})
+	if _, err := os.Stat(plistPath); err != nil {
+		t.Errorf("plist not written inside sandbox HOME: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Service loaded and started") {
+		t.Errorf("missing success message, got: %s", buf.String())
+	}
+}
+
+func TestInstallLaunchd_ForceReplacesLoadedDefinition(t *testing.T) {
+	callsFile := setupFakeTools(t, "", "")
+	plistPath := getLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, _ := newTestCmd()
+	if err := installLaunchdService(cmd, true); err != nil {
+		t.Fatalf("install --force failed: %v", err)
+	}
+
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"launchctl unload " + plistPath,
+		"launchctl load " + plistPath,
+	})
+	content, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "ai.canyonroad.agentsh.daemon") {
+		t.Errorf("plist not rewritten, still: %s", content)
+	}
+}
+
+func TestInstallLaunchd_ExistingPlistWithoutForce(t *testing.T) {
+	callsFile := setupFakeTools(t, "", "")
+	plistPath := getLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, buf := newTestCmd()
+	if err := installLaunchdService(cmd, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	if calls := recordedCalls(t, callsFile); calls != nil {
+		t.Errorf("expected no launchctl calls without --force, got %v", calls)
+	}
+	if !strings.Contains(buf.String(), "Use --force to overwrite") {
+		t.Errorf("missing --force hint, got: %s", buf.String())
+	}
+}
+
+func TestInstallLaunchd_LoadFailureIsError(t *testing.T) {
+	setupFakeTools(t, `[ "$1" = "load" ] && exit 1`, "")
+	cmd, _ := newTestCmd()
+
+	err := installLaunchdService(cmd, false)
+	if err == nil {
+		t.Fatal("expected error when launchctl load fails")
+	}
+	if !strings.Contains(err.Error(), getLaunchdPlistPath()) {
+		t.Errorf("error should mention plist path: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `go test ./internal/cli/ -run 'TestInstallLaunchd' -v`
+Expected: `TestInstallLaunchd_UnloadsBeforeLoad` and `TestInstallLaunchd_ForceReplacesLoadedDefinition` FAIL (recorded calls contain only `load`, no `unload`). `TestInstallLaunchd_LoadFailureIsError` FAILS (install returns nil — load failure is currently only a warning). `TestInstallLaunchd_ExistingPlistWithoutForce` passes (already-correct behavior, kept as a regression guard).
+
+- [ ] **Step 3: Add `reloadLaunchdService` and change the call sites**
+
+In `internal/cli/daemon.go`, add next to `getLaunchdPlistPath`:
+
+```go
+// reloadLaunchdService replaces whatever job definition launchd currently
+// holds with the plist on disk. The unload error is ignored: not-loaded is
+// the expected case on a fresh install.
+func reloadLaunchdService(plistPath string) error {
+	_ = exec.Command("launchctl", "unload", plistPath).Run()
+	return exec.Command("launchctl", "load", plistPath).Run()
+}
+```
+
+In `installLaunchdService`, replace the load block (currently `daemon.go:439-444`):
+
+```go
+	// Load the service, replacing any already-loaded definition — the normal
+	// case under --force, where an installation exists by definition (#439).
+	if err := reloadLaunchdService(plistPath); err != nil {
+		return fmt.Errorf("load service: %w (plist written to %s; load manually with: launchctl load %s)", err, plistPath, plistPath)
+	}
+	fmt.Fprintln(w, "Service loaded and started")
+```
+
+In `newDaemonRestartCmd`, replace the darwin branch's inline unload/load pair (currently `daemon.go:178-187`):
+
+```go
+		case "darwin":
+			fmt.Fprintln(w, "Restarting agentsh daemon...")
+			if err := reloadLaunchdService(getLaunchdPlistPath()); err != nil {
+				return fmt.Errorf("restart failed: %w", err)
+			}
+			fmt.Fprintln(w, "Daemon restarted successfully")
+			return nil
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run 'TestInstallLaunchd' -v`
+Expected: all four PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/daemon.go internal/cli/daemon_install_test.go
+git commit -m "fix(daemon): reload launchd service on install so --force takes effect (#439)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Linux — restart an active unit on install, hard-error on restart failure
+
+**Files:**
+- Modify: `internal/cli/daemon.go` (add `restartSystemdIfActive`; change `installSystemdService`)
+- Modify: `internal/cli/daemon_install_test.go`
+
+- [ ] **Step 1: Add the systemd tests**
+
+Append to `internal/cli/daemon_install_test.go`:
+
+```go
+func TestInstallSystemd_RestartsActiveUnit(t *testing.T) {
+	callsFile := setupFakeTools(t, "", `[ "$2" = "is-active" ] && { echo active; exit 0; }`)
+	cmd, buf := newTestCmd()
+
+	if err := installSystemdService(cmd, true); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable agentsh",
+		"systemctl --user is-active agentsh",
+		"systemctl --user restart agentsh",
+	})
+	unitPath := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user", "agentsh.service")
+	if _, err := os.Stat(unitPath); err != nil {
+		t.Errorf("unit not written inside sandbox HOME: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Service restarted with updated configuration") {
+		t.Errorf("missing restart message, got: %s", out)
+	}
+	if strings.Contains(out, "To start the daemon now") {
+		t.Errorf("start hint should be suppressed after a restart, got: %s", out)
+	}
+}
+
+func TestInstallSystemd_InactiveUnitNotRestarted(t *testing.T) {
+	callsFile := setupFakeTools(t, "", `[ "$2" = "is-active" ] && { echo inactive; exit 3; }`)
+	cmd, buf := newTestCmd()
+
+	if err := installSystemdService(cmd, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	for _, call := range recordedCalls(t, callsFile) {
+		if strings.Contains(call, " restart ") || strings.HasSuffix(call, " restart agentsh") {
+			t.Errorf("unexpected restart call: %s", call)
+		}
+	}
+	if !strings.Contains(buf.String(), "To start the daemon now") {
+		t.Errorf("start hint should be preserved when unit inactive, got: %s", buf.String())
+	}
+}
+
+func TestInstallSystemd_RestartFailureIsError(t *testing.T) {
+	setupFakeTools(t, "", `[ "$2" = "is-active" ] && { echo active; exit 0; }
+[ "$2" = "restart" ] && exit 1`)
+	cmd, _ := newTestCmd()
+
+	err := installSystemdService(cmd, true)
+	if err == nil {
+		t.Fatal("expected error when systemctl restart fails")
+	}
+	if !strings.Contains(err.Error(), "systemctl --user restart agentsh") {
+		t.Errorf("error should include manual remediation: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `go test ./internal/cli/ -run 'TestInstallSystemd' -v`
+Expected: `TestInstallSystemd_RestartsActiveUnit` FAILS (no `is-active`/`restart` calls recorded, no restart message). `TestInstallSystemd_RestartFailureIsError` FAILS (returns nil). `TestInstallSystemd_InactiveUnitNotRestarted` does NOT fail — it guards current behavior and must stay green through the change.
+
+- [ ] **Step 3: Add `restartSystemdIfActive` and the call site**
+
+In `internal/cli/daemon.go`, add next to `runSystemctl`:
+
+```go
+// restartSystemdIfActive restarts the agentsh user unit only when it is
+// currently active, so install is never the thing that first starts the
+// daemon on Linux. The bool reports whether a restart occurred. is-active is
+// queried via Output() rather than runSystemctl so "inactive" does not leak
+// to the terminal.
+func restartSystemdIfActive() (bool, error) {
+	out, err := exec.Command("systemctl", "--user", "is-active", "agentsh").Output()
+	if err != nil || strings.TrimSpace(string(out)) != "active" {
+		return false, nil
+	}
+	if err := runSystemctl("restart", "agentsh"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+```
+
+In `installSystemdService`, insert after the enable block and change the closing prints (currently `daemon.go:286-301`, through `return nil`) to:
+
+```go
+	// Enable service
+	if err := runSystemctl("enable", "agentsh"); err != nil {
+		fmt.Fprintf(w, "Warning: failed to enable service: %v\n", err)
+	} else {
+		fmt.Fprintln(w, "Service enabled for automatic start on login")
+	}
+
+	// A pre-existing daemon (notably under --force) keeps running the old
+	// ExecStart until bounced; restart so the new unit takes effect (#439).
+	restarted, err := restartSystemdIfActive()
+	if err != nil {
+		return fmt.Errorf("restart service: %w (unit written to %s; restart manually with: systemctl --user restart agentsh)", err, servicePath)
+	}
+	if restarted {
+		fmt.Fprintln(w, "Service restarted with updated configuration")
+	}
+
+	fmt.Fprintln(w)
+	if !restarted {
+		fmt.Fprintln(w, "To start the daemon now:")
+		fmt.Fprintln(w, "  systemctl --user start agentsh")
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintln(w, "To check status:")
+	fmt.Fprintln(w, "  systemctl --user status agentsh")
+	fmt.Fprintln(w, "  agentsh daemon status")
+
+	return nil
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run 'TestInstallSystemd' -v`
+Expected: all three PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/daemon.go internal/cli/daemon_install_test.go
+git commit -m "fix(daemon): restart active systemd unit on install so --force takes effect (#439)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full verification and PR
+
+- [ ] **Step 1: Format check**
+
+Run: `gofmt -l internal/cli/`
+Expected: no output.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `go test ./...`
+Expected: all packages PASS (or pre-existing skips only).
+
+- [ ] **Step 3: Cross-compile check (required by CLAUDE.md)**
+
+Run: `GOOS=windows go build ./... && GOOS=linux go build ./...`
+Expected: both succeed.
+
+- [ ] **Step 4: Manual macOS verification — coordinate with the user first**
+
+This step touches the real launchd session on the development machine; do not run it unattended. Per the issue: `agentsh daemon install`, mutate the plist (or install a build with different `ProgramArguments`), `agentsh daemon install --force`, then `launchctl list | grep agentsh` — the running job must reflect the new definition without a manual `agentsh daemon restart`. If the user prefers, skip and rely on CI + the fake-tool tests.
+
+- [ ] **Step 5: Push and open PR**
+
+Per the user's workflow: PR against `main`, wait for green CI, squash merge.
+
+```bash
+git push -u origin fix/439-daemon-install-reload
+gh pr create --title "fix(daemon): daemon install --force leaves the old service definition running (#439)" --body "$(cat <<'EOF'
+Fixes #439.
+
+`daemon install --force` rewrote the service file but never made the running
+service pick it up: on macOS `launchctl load` fails ("already loaded") and was
+downgraded to a warning, leaving the old job definition active; on Linux the
+unit was daemon-reloaded but a running daemon kept its old ExecStart.
+
+- macOS: install now unloads before loading (shared `reloadLaunchdService`
+  helper, also used by `daemon restart` so the two paths cannot drift again).
+- Linux: install now restarts the unit iff it is already active
+  (`restartSystemdIfActive`); install still never *starts* the daemon.
+- Load/restart failures are hard errors instead of exit-0 warnings — an
+  install that reports success while the daemon is not running is what hid
+  #437.
+- Home-dir resolution unified on `userHomeDir()` (was a `user.Current()` /
+  `os.UserHomeDir()` mix), which also lets tests sandbox via `$HOME`.
+- Regression tests with fake `launchctl`/`systemctl` binaries assert the exact
+  call sequences and error propagation on both platforms.
+
+Design spec: docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Then watch CI to green and squash merge (ask the user before merging if in doubt).

--- a/docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md
+++ b/docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md
@@ -1,0 +1,159 @@
+# Design: `daemon install --force` must reload the running service (#439)
+
+**Date:** 2026-08-05
+**Issue:** [#439](https://github.com/canyonroad/agentsh/issues/439)
+**Status:** Approved
+
+## Problem
+
+`agentsh daemon install --force` on macOS writes the new launchd plist but never
+reloads it. `launchctl load` fails with "service already loaded" — which is the
+normal case under `--force`, since an installation already exists — and the code
+downgrades the failure to a `Warning:` line and returns success. launchd keeps
+running the old job definition until a manual `agentsh daemon restart` or
+re-login. The #437 deprecation notice tells users to run exactly this command,
+so the documented remediation appears not to work.
+
+Linux has a milder variant: `installSystemdService` runs `daemon-reload` after
+rewriting the unit, but never restarts an already-running service, so the old
+`ExecStart` invocation keeps running until the next restart or login.
+
+Both platforms share a second defect: a failed load is reported as a warning and
+the command exits 0, so an install that leaves the daemon not running (or
+running stale) claims success. That masking is what let #437 go unnoticed.
+
+## Scope
+
+- Fix the macOS launchd install path (unload before load).
+- Linux parity: restart the systemd service on install when it is already
+  running.
+- Promote load/restart failures from warnings to hard errors.
+- Add regression tests for the command sequences and error propagation.
+
+Out of scope:
+
+- Migrating from `launchctl load`/`unload` to `bootstrap`/`bootout`. The file
+  uses `load`/`unload` consistently (install, restart, uninstall); modernizing
+  is a separate change.
+- Promoting `daemon-reload` / `enable` failures on Linux to hard errors.
+  Considered and deferred: those failures do not leave a *stale* service
+  running, and the unit still takes effect on next login. Revisit separately.
+- Windows service support (unchanged: unsupported message).
+
+## Design
+
+### Shared helpers in `internal/cli/daemon.go`
+
+```go
+// reloadLaunchdService replaces whatever job definition launchd currently
+// holds with the plist on disk. The unload error is ignored: not-loaded is
+// the expected case on a fresh install.
+func reloadLaunchdService(plistPath string) error {
+    _ = exec.Command("launchctl", "unload", plistPath).Run()
+    return exec.Command("launchctl", "load", plistPath).Run()
+}
+
+// restartSystemdIfActive restarts the agentsh user unit only when it is
+// currently active, so install keeps its existing behavior of never being
+// the thing that first starts the daemon on Linux. The bool reports whether
+// a restart occurred, so the caller can print the success message only in
+// that case.
+func restartSystemdIfActive() (restarted bool, err error)
+```
+
+`restartSystemdIfActive` checks `systemctl --user is-active agentsh` using
+`exec.Command(...).Output()` (as `getCurrentSession` already does), **not**
+`runSystemctl`, which wires stdout/stderr to the terminal and would leak
+`inactive` to the user. Only when the output is `active` does it run
+`systemctl --user restart agentsh` (via `runSystemctl`).
+
+### Call-site changes
+
+- `installLaunchdService`: replace the bare `launchctl load` with
+  `reloadLaunchdService(plistPath)`. On error, return a hard error whose
+  message states that the plist **was** written and gives the manual
+  remediation (`launchctl load <path>`). On success, keep printing
+  `Service loaded and started`.
+- `newDaemonRestartCmd` (darwin branch): call `reloadLaunchdService` instead of
+  its inline unload/load pair. Behavior is unchanged; install and restart can
+  no longer drift apart — drift between those two paths is what caused this
+  bug.
+- `installSystemdService`: after `daemon-reload` and `enable`, call
+  `restartSystemdIfActive()`. On error, return a hard error stating the unit
+  file was written and suggesting `systemctl --user restart agentsh`. When a
+  restart occurs, print `Service restarted with updated configuration`. When
+  the unit is not active, behavior is unchanged, including the
+  "To start the daemon now" hint.
+
+### Home-directory consistency (both install paths)
+
+`installLaunchdService` derives the LaunchAgents dir, log dir, and the plist's
+`HOME` environment variable from `user.Current().HomeDir`, while
+`getLaunchdPlistPath` uses `os.UserHomeDir()`. Under cgo, `user.Current()`
+ignores `$HOME`, so the two can disagree — and the mismatch blocks HOME-based
+test redirection. Unify on `os.UserHomeDir()`; `user.Current()` drops out of
+`installLaunchdService` entirely.
+
+`installSystemdService` has the same problem: the systemd unit dir, data dir,
+and the unit's `Environment=HOME=` value come from `user.Current().HomeDir`.
+Switch those to `os.UserHomeDir()` as well, for the same reason — without it,
+the Linux test cases below would write to the developer's real
+`~/.config/systemd/user/agentsh.service`. `user.Current()` remains in that
+function solely for `Uid` (the `XDG_RUNTIME_DIR=/run/user/%s` template value),
+which has no filesystem effect.
+
+Use the existing `userHomeDir()` helper (`internal/cli/root.go:99`) rather than
+calling `os.UserHomeDir()` directly — it already handles the error return by
+falling back to `$HOME`.
+
+## Error handling
+
+| Failure | Today | After |
+| --- | --- | --- |
+| `launchctl load` fails on install (macOS) | `Warning:`, exit 0 | Hard error, exit non-zero; message includes plist path + manual load command |
+| `systemctl restart` fails on install with active unit (Linux) | n/a (never attempted) | Hard error, exit non-zero; message includes manual restart command |
+| `launchctl unload` fails on install/restart | n/a / ignored | Ignored (not-loaded is the expected fresh-install case) |
+| `daemon-reload` / `enable` fail (Linux) | `Warning:`, exit 0 | Unchanged (deferred) |
+
+## Testing
+
+New tests in `internal/cli/daemon_test.go`, in the existing file's style
+(shell-script helpers, as `auto_daemon_test.go` already uses):
+
+- Fake `launchctl` and `systemctl` shell scripts in a `t.TempDir()` prepended
+  to `PATH`, appending their arguments to a calls file.
+- `t.Setenv("HOME", t.TempDir())` so plist/unit/data/log paths land in the
+  sandbox (enabled by the `os.UserHomeDir()` unification in **both** install
+  functions).
+- The install functions are not GOOS-gated at compile time, so these tests run
+  on both macOS and Linux CI. Skip on Windows (shell scripts).
+
+Cases:
+
+1. macOS fresh install: calls are `unload <plist>` then `load <plist>`, in
+   that order; command succeeds.
+2. macOS `--force` over an existing plist: same ordering assertion.
+3. macOS load failure (fake exits non-zero for `load`): install returns an
+   error mentioning the plist path.
+4. Linux `--force` with `is-active` reporting `active`: `restart agentsh` is
+   invoked after `daemon-reload`/`enable`.
+5. Linux `--force` with `is-active` reporting `inactive`: no `restart` call;
+   command succeeds.
+6. Linux restart failure with active unit: install returns an error.
+
+Manual verification on macOS before the PR merges, per the issue: install,
+mutate the plist, `install --force`, confirm `launchctl list` reflects the new
+definition without a manual restart.
+
+## Compatibility
+
+- Fresh installs: identical observable behavior on both platforms (the added
+  `unload` is a silent no-op).
+- macOS `--force`: the running daemon is now bounced to the new definition —
+  the behavior users already expect from the command.
+- Linux `--force` with a running daemon: the service restarts. This is a
+  deliberate behavior change and the point of the parity fix; a monitoring
+  daemon restart is momentary and `Restart=on-failure` semantics are
+  unaffected.
+- Scripts that relied on `install` exiting 0 despite a load failure will now
+  see a non-zero exit. That is the intended contract fix.

--- a/docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md
+++ b/docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md
@@ -50,7 +50,10 @@ Out of scope:
 // the expected case on a fresh install.
 func reloadLaunchdService(plistPath string) error {
     _ = exec.Command("launchctl", "unload", plistPath).Run()
-    return exec.Command("launchctl", "load", plistPath).Run()
+    out, err := exec.Command("launchctl", "load", plistPath).CombinedOutput()
+    // on failure, include launchctl's diagnostic output (it goes to stderr,
+    // so a bare exit status would be unactionable) in the returned error
+    ...
 }
 
 // restartSystemdIfActive restarts the agentsh user unit only when it is
@@ -114,10 +117,12 @@ falling back to `$HOME`.
 | `systemctl restart` fails on install with active unit (Linux) | n/a (never attempted) | Hard error, exit non-zero; message includes manual restart command |
 | `launchctl unload` fails on install/restart | n/a / ignored | Ignored (not-loaded is the expected fresh-install case) |
 | `daemon-reload` / `enable` fail (Linux) | `Warning:`, exit 0 | Unchanged (deferred) |
+| `is-active` query fails (Linux) | n/a | Treated as not-active; restart skipped (a broken systemctl already produced warnings above) |
 
 ## Testing
 
-New tests in `internal/cli/daemon_test.go`, in the existing file's style
+New tests in `internal/cli/daemon_install_test.go` (a new file, keeping the
+existing 385-line `daemon_test.go` focused), in the codebase's existing style
 (shell-script helpers, as `auto_daemon_test.go` already uses):
 
 - Fake `launchctl` and `systemctl` shell scripts in a `t.TempDir()` prepended

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -342,7 +342,8 @@ func uninstallSystemdService(cmd *cobra.Command) error {
 // currently active, so install is never the thing that first starts the
 // daemon on Linux. The bool reports whether a restart occurred. is-active is
 // queried via Output() rather than runSystemctl so "inactive" does not leak
-// to the terminal.
+// to the terminal. Any query error (including a broken systemctl, which
+// already produced warnings above) is treated as not-active.
 func restartSystemdIfActive() (bool, error) {
 	out, err := exec.Command("systemctl", "--user", "is-active", "agentsh").Output()
 	if err != nil || strings.TrimSpace(string(out)) != "active" {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -374,8 +374,7 @@ const launchdPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 `
 
 func getLaunchdPlistPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, "Library", "LaunchAgents", "ai.canyonroad.agentsh.daemon.plist")
+	return filepath.Join(userHomeDir(), "Library", "LaunchAgents", "ai.canyonroad.agentsh.daemon.plist")
 }
 
 // reloadLaunchdService replaces whatever job definition launchd currently
@@ -383,7 +382,14 @@ func getLaunchdPlistPath() string {
 // the expected case on a fresh install.
 func reloadLaunchdService(plistPath string) error {
 	_ = exec.Command("launchctl", "unload", plistPath).Run()
-	return exec.Command("launchctl", "load", plistPath).Run()
+	out, err := exec.Command("launchctl", "load", plistPath).CombinedOutput()
+	if err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 func installLaunchdService(cmd *cobra.Command, force bool) error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -230,6 +230,7 @@ func installSystemdService(cmd *cobra.Command, force bool) error {
 	if err != nil {
 		return fmt.Errorf("get current user: %w", err)
 	}
+	home := userHomeDir()
 
 	// Get agentsh binary path
 	exePath, err := os.Executable()
@@ -242,7 +243,7 @@ func installSystemdService(cmd *cobra.Command, force bool) error {
 	}
 
 	// Ensure systemd user directory exists
-	systemdDir := filepath.Join(currentUser.HomeDir, ".config", "systemd", "user")
+	systemdDir := filepath.Join(home, ".config", "systemd", "user")
 	if err := os.MkdirAll(systemdDir, 0755); err != nil {
 		return fmt.Errorf("create systemd directory: %w", err)
 	}
@@ -257,7 +258,7 @@ func installSystemdService(cmd *cobra.Command, force bool) error {
 	}
 
 	// Data directory for read-write access
-	dataDir := filepath.Join(currentUser.HomeDir, ".local", "share", "agentsh")
+	dataDir := filepath.Join(home, ".local", "share", "agentsh")
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		return fmt.Errorf("create data directory: %w", err)
 	}
@@ -265,7 +266,7 @@ func installSystemdService(cmd *cobra.Command, force bool) error {
 	// Generate service content
 	serviceContent := fmt.Sprintf(systemdServiceTemplate,
 		exePath,
-		currentUser.HomeDir,
+		home,
 		currentUser.Uid,
 		dataDir,
 	)
@@ -304,12 +305,7 @@ func installSystemdService(cmd *cobra.Command, force bool) error {
 func uninstallSystemdService(cmd *cobra.Command) error {
 	w := cmd.OutOrStdout()
 
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %w", err)
-	}
-
-	servicePath := filepath.Join(currentUser.HomeDir, ".config", "systemd", "user", "agentsh.service")
+	servicePath := filepath.Join(userHomeDir(), ".config", "systemd", "user", "agentsh.service")
 
 	// Stop service if running
 	_ = runSystemctl("stop", "agentsh")
@@ -388,10 +384,7 @@ func getLaunchdPlistPath() string {
 func installLaunchdService(cmd *cobra.Command, force bool) error {
 	w := cmd.OutOrStdout()
 
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("get current user: %w", err)
-	}
+	home := userHomeDir()
 
 	exePath, err := os.Executable()
 	if err != nil {
@@ -403,7 +396,7 @@ func installLaunchdService(cmd *cobra.Command, force bool) error {
 	}
 
 	// Ensure LaunchAgents directory exists
-	launchAgentsDir := filepath.Join(currentUser.HomeDir, "Library", "LaunchAgents")
+	launchAgentsDir := filepath.Join(home, "Library", "LaunchAgents")
 	if err := os.MkdirAll(launchAgentsDir, 0755); err != nil {
 		return fmt.Errorf("create LaunchAgents directory: %w", err)
 	}
@@ -417,7 +410,7 @@ func installLaunchdService(cmd *cobra.Command, force bool) error {
 	}
 
 	// Log directory
-	logDir := filepath.Join(currentUser.HomeDir, "Library", "Logs", "agentsh")
+	logDir := filepath.Join(home, "Library", "Logs", "agentsh")
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return fmt.Errorf("create log directory: %w", err)
 	}
@@ -426,7 +419,7 @@ func installLaunchdService(cmd *cobra.Command, force bool) error {
 		exePath,
 		logDir,
 		logDir,
-		currentUser.HomeDir,
+		home,
 	)
 
 	if err := os.WriteFile(plistPath, []byte(plistContent), 0644); err != nil {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -288,10 +288,22 @@ func installSystemdService(cmd *cobra.Command, force bool) error {
 		fmt.Fprintln(w, "Service enabled for automatic start on login")
 	}
 
+	// A pre-existing daemon (notably under --force) keeps running the old
+	// ExecStart until bounced; restart so the new unit takes effect (#439).
+	restarted, err := restartSystemdIfActive()
+	if err != nil {
+		return fmt.Errorf("restart service: %w (unit written to %s; restart manually with: systemctl --user restart agentsh)", err, servicePath)
+	}
+	if restarted {
+		fmt.Fprintln(w, "Service restarted with updated configuration")
+	}
+
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "To start the daemon now:")
-	fmt.Fprintln(w, "  systemctl --user start agentsh")
-	fmt.Fprintln(w)
+	if !restarted {
+		fmt.Fprintln(w, "To start the daemon now:")
+		fmt.Fprintln(w, "  systemctl --user start agentsh")
+		fmt.Fprintln(w)
+	}
 	fmt.Fprintln(w, "To check status:")
 	fmt.Fprintln(w, "  systemctl --user status agentsh")
 	fmt.Fprintln(w, "  agentsh daemon status")
@@ -324,6 +336,22 @@ func uninstallSystemdService(cmd *cobra.Command) error {
 
 	fmt.Fprintln(w, "Service uninstalled successfully")
 	return nil
+}
+
+// restartSystemdIfActive restarts the agentsh user unit only when it is
+// currently active, so install is never the thing that first starts the
+// daemon on Linux. The bool reports whether a restart occurred. is-active is
+// queried via Output() rather than runSystemctl so "inactive" does not leak
+// to the terminal.
+func restartSystemdIfActive() (bool, error) {
+	out, err := exec.Command("systemctl", "--user", "is-active", "agentsh").Output()
+	if err != nil || strings.TrimSpace(string(out)) != "active" {
+		return false, nil
+	}
+	if err := runSystemctl("restart", "agentsh"); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func runSystemctl(action, service string) error {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -177,10 +177,7 @@ This stops the current daemon, clears session state, and starts a new session.`,
 
 			case "darwin":
 				fmt.Fprintln(w, "Restarting agentsh daemon...")
-				// Unload and reload the service
-				plistPath := getLaunchdPlistPath()
-				_ = exec.Command("launchctl", "unload", plistPath).Run()
-				if err := exec.Command("launchctl", "load", plistPath).Run(); err != nil {
+				if err := reloadLaunchdService(getLaunchdPlistPath()); err != nil {
 					return fmt.Errorf("restart failed: %w", err)
 				}
 				fmt.Fprintln(w, "Daemon restarted successfully")
@@ -381,6 +378,14 @@ func getLaunchdPlistPath() string {
 	return filepath.Join(home, "Library", "LaunchAgents", "ai.canyonroad.agentsh.daemon.plist")
 }
 
+// reloadLaunchdService replaces whatever job definition launchd currently
+// holds with the plist on disk. The unload error is ignored: not-loaded is
+// the expected case on a fresh install.
+func reloadLaunchdService(plistPath string) error {
+	_ = exec.Command("launchctl", "unload", plistPath).Run()
+	return exec.Command("launchctl", "load", plistPath).Run()
+}
+
 func installLaunchdService(cmd *cobra.Command, force bool) error {
 	w := cmd.OutOrStdout()
 
@@ -429,12 +434,12 @@ func installLaunchdService(cmd *cobra.Command, force bool) error {
 	fmt.Fprintf(w, "Service installed: %s\n", plistPath)
 	fmt.Fprintln(w)
 
-	// Load the service
-	if err := exec.Command("launchctl", "load", plistPath).Run(); err != nil {
-		fmt.Fprintf(w, "Warning: failed to load service: %v\n", err)
-	} else {
-		fmt.Fprintln(w, "Service loaded and started")
+	// Load the service, replacing any already-loaded definition — the normal
+	// case under --force, where an installation exists by definition (#439).
+	if err := reloadLaunchdService(plistPath); err != nil {
+		return fmt.Errorf("load service: %w (plist written to %s; load manually with: launchctl load %s)", err, plistPath, plistPath)
 	}
+	fmt.Fprintln(w, "Service loaded and started")
 
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "To check status:")

--- a/internal/cli/daemon_install_test.go
+++ b/internal/cli/daemon_install_test.go
@@ -154,3 +154,62 @@ func TestInstallLaunchd_LoadFailureIsError(t *testing.T) {
 		t.Errorf("error should include launchctl diagnostic output: %v", err)
 	}
 }
+
+func TestInstallSystemd_RestartsActiveUnit(t *testing.T) {
+	callsFile := setupFakeTools(t, "", `[ "$2" = "is-active" ] && { echo active; exit 0; }`)
+	cmd, buf := newTestCmd()
+
+	if err := installSystemdService(cmd, true); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable agentsh",
+		"systemctl --user is-active agentsh",
+		"systemctl --user restart agentsh",
+	})
+	unitPath := filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user", "agentsh.service")
+	if _, err := os.Stat(unitPath); err != nil {
+		t.Errorf("unit not written inside sandbox HOME: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Service restarted with updated configuration") {
+		t.Errorf("missing restart message, got: %s", out)
+	}
+	if strings.Contains(out, "To start the daemon now") {
+		t.Errorf("start hint should be suppressed after a restart, got: %s", out)
+	}
+}
+
+func TestInstallSystemd_InactiveUnitNotRestarted(t *testing.T) {
+	callsFile := setupFakeTools(t, "", `[ "$2" = "is-active" ] && { echo inactive; exit 3; }`)
+	cmd, buf := newTestCmd()
+
+	if err := installSystemdService(cmd, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	for _, call := range recordedCalls(t, callsFile) {
+		if strings.Contains(call, " restart ") || strings.HasSuffix(call, " restart agentsh") {
+			t.Errorf("unexpected restart call: %s", call)
+		}
+	}
+	if !strings.Contains(buf.String(), "To start the daemon now") {
+		t.Errorf("start hint should be preserved when unit inactive, got: %s", buf.String())
+	}
+}
+
+func TestInstallSystemd_RestartFailureIsError(t *testing.T) {
+	setupFakeTools(t, "", `[ "$2" = "is-active" ] && { echo active; exit 0; }
+[ "$2" = "restart" ] && exit 1`)
+	cmd, _ := newTestCmd()
+
+	err := installSystemdService(cmd, true)
+	if err == nil {
+		t.Fatal("expected error when systemctl restart fails")
+	}
+	if !strings.Contains(err.Error(), "systemctl --user restart agentsh") {
+		t.Errorf("error should include manual remediation: %v", err)
+	}
+}

--- a/internal/cli/daemon_install_test.go
+++ b/internal/cli/daemon_install_test.go
@@ -139,6 +139,21 @@ func TestInstallLaunchd_ExistingPlistWithoutForce(t *testing.T) {
 	}
 }
 
+func TestInstallLaunchd_FreshInstallToleratesUnloadFailure(t *testing.T) {
+	callsFile := setupFakeTools(t, `[ "$1" = "unload" ] && exit 1`, "")
+	cmd, _ := newTestCmd()
+
+	if err := installLaunchdService(cmd, false); err != nil {
+		t.Fatalf("install should succeed when unload fails (job not loaded): %v", err)
+	}
+
+	plistPath := getLaunchdPlistPath()
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"launchctl unload " + plistPath,
+		"launchctl load " + plistPath,
+	})
+}
+
 func TestInstallLaunchd_LoadFailureIsError(t *testing.T) {
 	setupFakeTools(t, `[ "$1" = "load" ] && { echo "Load failed: 5: input/output error" >&2; exit 1; }`, "")
 	cmd, _ := newTestCmd()

--- a/internal/cli/daemon_install_test.go
+++ b/internal/cli/daemon_install_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// setupFakeTools installs fake launchctl/systemctl executables on PATH that
+// append each invocation to a calls file, and redirects HOME to a temp dir so
+// service files land in the test sandbox. The body script runs after the call
+// is recorded and controls the fake's behavior; an empty body means exit 0.
+func setupFakeTools(t *testing.T, launchctlBody, systemctlBody string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-tool tests require /bin/sh")
+	}
+	binDir := t.TempDir()
+	callsFile := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("AGENTSH_TEST_CALLS", callsFile)
+	writeTool := func(name, body string) {
+		script := "#!/bin/sh\n" +
+			"echo \"$(basename \"$0\") $@\" >> \"$AGENTSH_TEST_CALLS\"\n" +
+			body + "\nexit 0\n"
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	writeTool("launchctl", launchctlBody)
+	writeTool("systemctl", systemctlBody)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("HOME", t.TempDir())
+	return callsFile
+}
+
+// recordedCalls returns the fake-tool invocations, one per line, or nil if no
+// tool was ever called.
+func recordedCalls(t *testing.T, callsFile string) []string {
+	t.Helper()
+	data, err := os.ReadFile(callsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read calls file: %v", err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func newTestCmd() (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	return cmd, buf
+}
+
+func assertCalls(t *testing.T, got, want []string) {
+	t.Helper()
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("recorded calls:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestInstallLaunchd_UnloadsBeforeLoad(t *testing.T) {
+	callsFile := setupFakeTools(t, "", "")
+	cmd, buf := newTestCmd()
+
+	if err := installLaunchdService(cmd, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	plistPath := getLaunchdPlistPath()
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"launchctl unload " + plistPath,
+		"launchctl load " + plistPath,
+	})
+	if _, err := os.Stat(plistPath); err != nil {
+		t.Errorf("plist not written inside sandbox HOME: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Service loaded and started") {
+		t.Errorf("missing success message, got: %s", buf.String())
+	}
+}
+
+func TestInstallLaunchd_ForceReplacesLoadedDefinition(t *testing.T) {
+	callsFile := setupFakeTools(t, "", "")
+	plistPath := getLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, _ := newTestCmd()
+	if err := installLaunchdService(cmd, true); err != nil {
+		t.Fatalf("install --force failed: %v", err)
+	}
+
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"launchctl unload " + plistPath,
+		"launchctl load " + plistPath,
+	})
+	content, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "ai.canyonroad.agentsh.daemon") {
+		t.Errorf("plist not rewritten, still: %s", content)
+	}
+}
+
+func TestInstallLaunchd_ExistingPlistWithoutForce(t *testing.T) {
+	callsFile := setupFakeTools(t, "", "")
+	plistPath := getLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, buf := newTestCmd()
+	if err := installLaunchdService(cmd, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	if calls := recordedCalls(t, callsFile); calls != nil {
+		t.Errorf("expected no launchctl calls without --force, got %v", calls)
+	}
+	if !strings.Contains(buf.String(), "Use --force to overwrite") {
+		t.Errorf("missing --force hint, got: %s", buf.String())
+	}
+}
+
+func TestInstallLaunchd_LoadFailureIsError(t *testing.T) {
+	setupFakeTools(t, `[ "$1" = "load" ] && exit 1`, "")
+	cmd, _ := newTestCmd()
+
+	err := installLaunchdService(cmd, false)
+	if err == nil {
+		t.Fatal("expected error when launchctl load fails")
+	}
+	if !strings.Contains(err.Error(), getLaunchdPlistPath()) {
+		t.Errorf("error should mention plist path: %v", err)
+	}
+}

--- a/internal/cli/daemon_install_test.go
+++ b/internal/cli/daemon_install_test.go
@@ -140,7 +140,7 @@ func TestInstallLaunchd_ExistingPlistWithoutForce(t *testing.T) {
 }
 
 func TestInstallLaunchd_LoadFailureIsError(t *testing.T) {
-	setupFakeTools(t, `[ "$1" = "load" ] && exit 1`, "")
+	setupFakeTools(t, `[ "$1" = "load" ] && { echo "Load failed: 5: input/output error" >&2; exit 1; }`, "")
 	cmd, _ := newTestCmd()
 
 	err := installLaunchdService(cmd, false)
@@ -149,5 +149,8 @@ func TestInstallLaunchd_LoadFailureIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), getLaunchdPlistPath()) {
 		t.Errorf("error should mention plist path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Load failed: 5") {
+		t.Errorf("error should include launchctl diagnostic output: %v", err)
 	}
 }

--- a/internal/cli/daemon_install_test.go
+++ b/internal/cli/daemon_install_test.go
@@ -190,11 +190,11 @@ func TestInstallSystemd_InactiveUnitNotRestarted(t *testing.T) {
 		t.Fatalf("install failed: %v", err)
 	}
 
-	for _, call := range recordedCalls(t, callsFile) {
-		if strings.Contains(call, " restart ") || strings.HasSuffix(call, " restart agentsh") {
-			t.Errorf("unexpected restart call: %s", call)
-		}
-	}
+	assertCalls(t, recordedCalls(t, callsFile), []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable agentsh",
+		"systemctl --user is-active agentsh",
+	})
 	if !strings.Contains(buf.String(), "To start the daemon now") {
 		t.Errorf("start hint should be preserved when unit inactive, got: %s", buf.String())
 	}
@@ -211,5 +211,8 @@ func TestInstallSystemd_RestartFailureIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "systemctl --user restart agentsh") {
 		t.Errorf("error should include manual remediation: %v", err)
+	}
+	if !strings.Contains(err.Error(), filepath.Join(".config", "systemd", "user", "agentsh.service")) {
+		t.Errorf("error should mention unit path: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #439.

`daemon install --force` rewrote the service file but never made the running
service pick it up: on macOS `launchctl load` fails ("already loaded") and was
downgraded to a warning, leaving the old job definition active; on Linux the
unit was daemon-reloaded but a running daemon kept its old ExecStart.

- macOS: install now unloads before loading (shared `reloadLaunchdService`
  helper, also used by `daemon restart` so the two paths cannot drift again).
  Load errors carry launchctl's stderr diagnostics.
- Linux: install now restarts the unit iff it is already active
  (`restartSystemdIfActive`); install still never *starts* the daemon.
- Load/restart failures are hard errors instead of exit-0 warnings — an
  install that reports success while the daemon is not running is what hid
  #437.
- Home-dir resolution unified on `userHomeDir()` (was a `user.Current()` /
  `os.UserHomeDir()` mix), which also lets tests sandbox via `$HOME`.
- Regression tests with fake `launchctl`/`systemctl` binaries assert the exact
  call sequences and error propagation on both platforms (8 tests, run on
  macOS and Linux CI alike).

Design spec: docs/superpowers/specs/2026-08-05-daemon-install-reload-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)