### PR TITLE
fix(#441): detect gates esf on sysext liveness, not activation

### DIFF
--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -26,7 +26,7 @@ Security enforcement is provided through a combination of:
 
 | Mode | Requirements | Protection Level | Description |
 |------|--------------|------------------|-------------|
-| `esf` | System extension approved | ~90% | Endpoint Security Framework (Alpha) |
+| `esf` | System extension approved and running | ~90% | Endpoint Security Framework (Alpha) |
 | `lima` | limactl available | ~85% | Full Linux enforcement inside Lima VM |
 | `observation` | None | ~25% | Observation-only, no enforcement |
 

--- a/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
+++ b/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
@@ -874,6 +874,8 @@ git commit -m "fix(#441): enterprise tier requires a running sysext, not merely 
 
 ### Task 7: `SysExtManager.Status()` tells the truth; stub parity
 
+> **Amended during execution** (see the Task 7 commit): `LastExit` is surfaced only when not running (spec amendment #5); `SysExtStatus` gained `ProbeFailed` (both build variants); the mapping test grew `wantState`/`wantProbeFailed` columns plus running-after-crash and systemextensionsctl-failure rows — mutation-verified against the suppression gate, the State passthrough, and the ProbeFailed→Error clause. `NewSysExtManager` uses the `sysExtBundleID` const; `Status()` documents the bundle-presence precondition and Installed-means-activated semantics. The committed code is authoritative over the blocks below.
+
 **Files:**
 - Modify: `internal/platform/darwin/sysext.go`
 - Modify: `internal/platform/darwin/sysext_stub.go`

--- a/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
+++ b/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
@@ -561,6 +561,8 @@ git commit -m "feat(#441): CheckSysExtLiveness — fail-closed sysext liveness p
 
 ### Task 4: Wire `detect_darwin.go` onto the helper
 
+> **Amended during execution** (see the Task 4 commit): the caps literal was extracted into a pure `darwinCaps(liveness)` function with a mutation-verified table test (guards the exact Running/Activated transposition that would reintroduce #441); caps gained `esf_probe_failed`; the Command Control esf backend's `CheckMethod` was corrected from `"entitlement"` to `"sysext"`; `docs/security-modes.md` gained "and running". The committed code is authoritative over the blocks below.
+
 **Files:**
 - Modify: `internal/capabilities/detect_darwin.go` (delete `checkSysExtInstalled` at lines 110-122; change `Detect()` and `buildDarwinDomains`)
 - Modify: `internal/capabilities/detect_darwin_test.go`
@@ -665,6 +667,8 @@ git commit -m "fix(#441): detect gates esf on sysext liveness, not activation"
 
 ### Task 5: Reason-sensitive esf tips
 
+> **Amended during execution** (see the Task 5 commit and spec amendment #6): entry ordering is `OS_REASON_EXEC` → `could not be verified` → `not running` → fallback (probe-failure Details embed third-party stderr that can contain "not running"; pinned by the `noisy` test). Action texts enriched: Full Disk Access named as the most common not-running cause, `/usr/bin/log show` with a `process ==` predicate (NOT `subsystem ==` — the sysext logs under its bundle ID as process), concrete provisionprofile check + upgrade-not-reinstall guidance on the AMFI tip, resolvable TeamID placeholders, no bare issue references in user-facing text. The committed code is authoritative over the blocks below.
+
 **Files:**
 - Modify: `internal/capabilities/tips.go` (the `"esf"` entry in `tipsByBackend` ~line 178; the esf entry in `darwinTips` ~line 74)
 - Modify: `internal/capabilities/tips_test.go`
@@ -745,6 +749,8 @@ git commit -m "feat(#441): reason-sensitive esf tips (AMFI, not-running, unverif
 ---
 
 ### Task 6: Honest permission tier in `permissions.go`
+
+> **Amended during execution** (see the Task 6 commit): `Permissions` also gained `SysExtProbeFailed`, and `computeMissingPermissions` is a three-way switch (probe failure → "could not be verified" wording embedding the Detail, never install guidance nor a not-running overclaim). The mapping `liveness.Running → HasSystemExtension` is pinned by an injected-runner test (mutation-verified — the transposition IS bug #441). The committed code is authoritative over the blocks below.
 
 **Files:**
 - Modify: `internal/platform/darwin/permissions.go`

--- a/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
+++ b/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
@@ -25,6 +25,8 @@
 
 ### Task 1: `parseSysExtList` — per-line activation + team-ID parsing
 
+> **Amended during execution** (see the Task 1 commit): code review hardened `parseSysExtList` — activation now requires an exact bundle-ID field token (immune to prefix-sibling bundles like `...SysExtBeta`), scanning continues past rows that yield no team ID, and `"*"` is rejected as a team ID (blank-column marker). `runLivenessCommand` additionally folds captured stderr — whitespace-collapsed to one line — into returned errors so probe diagnostics carry the tool's actual message. Three regression subtests were added. The committed code is authoritative over the blocks below.
+
 **Files:**
 - Create: `internal/platform/darwin/sysext_liveness.go`
 - Create: `internal/platform/darwin/sysext_liveness_test.go`

--- a/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
+++ b/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
@@ -1,0 +1,1022 @@
+# ESF Liveness-Gated Detect Implementation Plan (issue #441)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `agentsh detect` (and the tier/status surfaces) report `esf` available only when the system extension *process is provably running*, not merely activated — with diagnostics explaining why when it isn't.
+
+**Architecture:** One new liveness helper in `internal/platform/darwin` (`CheckSysExtLiveness`) parses `systemextensionsctl list` (activation + team ID) and `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` (service state), failing closed on any probe failure. The three existing activation-only call sites (`capabilities/detect_darwin.go`, `platform/darwin/permissions.go`, `platform/darwin/sysext.go`) collapse onto it. Reason-sensitive tips in `capabilities/tips.go` turn the liveness `Detail` string into actionable guidance (e.g. `OS_REASON_EXEC` → AMFI/provisioning-profile hint).
+
+**Tech Stack:** Go stdlib only (`os/exec` with `CommandContext` timeouts, pure string parsing). Tests: std `testing` in `platform/darwin` and `detect_darwin_test.go`; `testify/assert` in `tips_test.go` (existing per-file conventions).
+
+**Spec:** `docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md` — read it before starting; its decision table is normative.
+
+**Branch:** work on `issue-441-esf-liveness-detect` (already exists, contains the spec commit).
+
+**Module path:** `github.com/agentsh/agentsh`
+
+**Verified environment facts** (from design session, on a machine exhibiting the bug):
+- `systemextensionsctl list` row format (tab-separated, bundle ID appears TWICE — as identifier and display name):
+  `*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]`
+- `launchctl print system/<TeamID>.<bundleID>` works unprivileged; service-level `state = …` is the FIRST `state =` line; nested sub-sections contain their own `state = active` lines.
+- `platform/darwin` builds without CGO (`sysext_activate_nocgo.go` fallback), and nothing in `platform/darwin` imports `internal/capabilities` — the new `capabilities → platform/darwin` edge is verified acyclic, so no build-graph risk.
+- `DetectResult.Table()` already renders `DetectedBackend.Detail` — no rendering changes needed.
+
+---
+
+### Task 1: `parseSysExtList` — per-line activation + team-ID parsing
+
+**Files:**
+- Create: `internal/platform/darwin/sysext_liveness.go`
+- Create: `internal/platform/darwin/sysext_liveness_test.go`
+- Modify: `internal/platform/darwin/sysext_activate_cgo.go:115` (delete its duplicate `sysExtBundleID` const)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/platform/darwin/sysext_liveness_test.go`:
+
+```go
+//go:build darwin
+
+package darwin
+
+import "testing"
+
+// Real output captured 2026-08-05 from a machine where the agentsh sysext is
+// activated but AMFI/launchd keeps it from running (the #441 specimen). Note
+// the co-installed beacon extension: whole-output substring matching would
+// false-positive on it.
+const sysextListBoth = `2 extension(s)
+--- com.apple.system_extension.endpoint_security (Go to 'System Settings > General > Login Items & Extensions > Endpoint Security Extensions' to modify these system extension(s))
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]
+*	*	WCKWMMKJ35	ai.canyonroad.beacon.sysext (0.1.0/1781653639)	Beacon System Extension	[activated enabled]
+`
+
+const sysextListBeaconOnly = `1 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*	WCKWMMKJ35	ai.canyonroad.beacon.sysext (0.1.0/1781653639)	Beacon System Extension	[activated enabled]
+`
+
+const sysextListWaiting = `1 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+		WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated waiting for user]
+`
+
+// Upgrade transient: old version terminating, new one activated enabled.
+const sysextListUpgrade = `2 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+		WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/13)	ai.canyonroad.agentsh.SysExt	[terminated waiting to uninstall on reboot]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]
+`
+
+func TestParseSysExtList(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		wantActivated bool
+		wantTeamID    string
+	}{
+		{"activated with neighbor extension", sysextListBoth, true, "WCKWMMKJ35"},
+		{"neighbor only must not match", sysextListBeaconOnly, false, ""},
+		{"waiting for user is not activated", sysextListWaiting, false, ""},
+		{"upgrade transient finds enabled row", sysextListUpgrade, true, "WCKWMMKJ35"},
+		{"empty output", "", false, ""},
+		{"garbage output", "no extensions here\njust noise\n", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			activated, teamID := parseSysExtList(tt.output)
+			if activated != tt.wantActivated {
+				t.Errorf("activated = %v, want %v", activated, tt.wantActivated)
+			}
+			if teamID != tt.wantTeamID {
+				t.Errorf("teamID = %q, want %q", teamID, tt.wantTeamID)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/platform/darwin/ -run TestParseSysExtList -v`
+Expected: FAIL to build with `undefined: parseSysExtList`
+
+- [ ] **Step 3: Write minimal implementation**
+
+First, delete line 115 of `internal/platform/darwin/sysext_activate_cgo.go`:
+
+```go
+const sysExtBundleID = "ai.canyonroad.agentsh.SysExt"
+```
+
+That file is `//go:build darwin && cgo`, so with CGO enabled (the default on macOS) it compiles into the same package and would collide with the const below. `sysext_liveness.go` (plain `//go:build darwin`) becomes the owner — it is built on darwin both with and without cgo, so the remaining use at `sysext_activate_cgo.go:120` keeps compiling in every build mode.
+
+Then create `internal/platform/darwin/sysext_liveness.go`:
+
+```go
+//go:build darwin
+
+package darwin
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	sysExtBundleID     = "ai.canyonroad.agentsh.SysExt"
+	livenessCmdTimeout = 5 * time.Second
+)
+
+// SysExtLiveness reports two separate facts about the system extension:
+// whether it is activated (systemextensionsctl) and whether its process is
+// actually running (launchd service state). Running is set only on positive
+// proof (state = running); every probe failure fails closed (issue #441 —
+// an activated-but-AMFI-blocked extension must not report as healthy).
+type SysExtLiveness struct {
+	Activated   bool   // systemextensionsctl row for our bundle ID says "activated enabled"
+	Running     bool   // launchctl service state is "running"
+	ProbeFailed bool   // a probe command failed or its output was unparseable (Running stays false)
+	State       string // raw launchd state ("running", "spawn scheduled", ...); "" if unknown
+	LastExit    string // "exit code 1", "OS_REASON_EXEC ...", ...; "" if none
+	Detail      string // human-readable one-liner; tips.go matches substrings of this
+}
+
+// runLivenessCommand executes a probe command with a timeout. Package-level
+// var so tests can inject fixture output.
+var runLivenessCommand = func(name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), livenessCmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	return string(out), err
+}
+
+// parseSysExtList scans systemextensionsctl list output line by line for an
+// "activated enabled" row belonging to our bundle ID, and extracts the team
+// ID from that row. The team ID is the field immediately preceding the FIRST
+// occurrence of the bundle-ID token: the row repeats the bundle ID as its
+// display name, so matching the last occurrence would return the version
+// column instead. Per-line matching also prevents a different extension's
+// "activated enabled" from satisfying the check.
+func parseSysExtList(output string) (activated bool, teamID string) {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, sysExtBundleID) ||
+			!strings.Contains(line, "activated enabled") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for i, f := range fields {
+			if f == sysExtBundleID {
+				if i > 0 {
+					return true, fields[i-1]
+				}
+				return true, ""
+			}
+		}
+		return true, ""
+	}
+	return false, ""
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/platform/darwin/ -run TestParseSysExtList -v`
+Expected: PASS (all 6 subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sysext_liveness.go internal/platform/darwin/sysext_liveness_test.go internal/platform/darwin/sysext_activate_cgo.go
+git commit -m "feat(#441): parseSysExtList — per-line activation + team-ID parsing"
+```
+
+---
+
+### Task 2: `parseLaunchdState` — service state + last-exit extraction
+
+**Files:**
+- Modify: `internal/platform/darwin/sysext_liveness.go` (append function)
+- Modify: `internal/platform/darwin/sysext_liveness_test.go` (append fixtures + test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/platform/darwin/sysext_liveness_test.go`:
+
+```go
+// Trimmed real output (2026-08-05) from the #441 specimen machine. The
+// nested "state = active" lines below the top-level state are real — the
+// parser must take only the FIRST "state =" line.
+const launchdSpawnScheduled = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 0
+	path = (submitted by smd[532])
+	type = Submitted
+	state = spawn scheduled
+
+	program = /Library/SystemExtensions/0FED1DDB-30D3-4AAD-A31C-8E7F1229868E/ai.canyonroad.agentsh.SysExt.systemextension/Contents/MacOS/ai.canyonroad.agentsh.SysExt
+	domain = system
+	minimum runtime = 10
+	exit timeout = 5
+	runs = 199773
+	last exit code = 1
+
+	event triggers = {
+		ai.canyonroad.agentsh.SysExt => {
+			state = active
+		}
+		ai.canyonroad.agentsh.SysExt.esf => {
+			state = active
+		}
+	}
+}
+`
+
+const launchdRunning = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 1
+	path = (submitted by smd[532])
+	type = Submitted
+	state = running
+
+	program = /Library/SystemExtensions/0FED1DDB-30D3-4AAD-A31C-8E7F1229868E/ai.canyonroad.agentsh.SysExt.systemextension/Contents/MacOS/ai.canyonroad.agentsh.SysExt
+	pid = 4242
+	domain = system
+	runs = 1
+	last exit code = (never exited)
+}
+`
+
+// Synthesized from the #436 report (AMFI rejects the binary at exec).
+const launchdAMFIBlocked = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 0
+	state = spawn scheduled
+	runs = 324
+	last exit reason = OS_REASON_EXEC | Error -413 "No matching profile found"
+	last exit code = (never exited)
+}
+`
+
+func TestParseLaunchdState(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		wantState    string
+		wantLastExit string
+	}{
+		{"spawn scheduled with exit code", launchdSpawnScheduled, "spawn scheduled", "exit code 1"},
+		{"running, never exited suppressed", launchdRunning, "running", ""},
+		{"amfi blocked reason preferred over code", launchdAMFIBlocked, "spawn scheduled", `OS_REASON_EXEC | Error -413 "No matching profile found"`},
+		{"no state line", "system/x = {\n\truns = 3\n}\n", "", ""},
+		{"empty output", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, lastExit := parseLaunchdState(tt.output)
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			if lastExit != tt.wantLastExit {
+				t.Errorf("lastExit = %q, want %q", lastExit, tt.wantLastExit)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/platform/darwin/ -run TestParseLaunchdState -v`
+Expected: FAIL to build with `undefined: parseLaunchdState`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/platform/darwin/sysext_liveness.go`:
+
+```go
+// parseLaunchdState extracts the service-level state and last-exit info from
+// `launchctl print system/<label>` output. Only the FIRST "state =" line is
+// the service state: nested sub-sections (event triggers, XPC endpoints)
+// contain their own "state = active" lines. "last exit reason" (present on
+// exec-level failures like AMFI rejection, per #436) is preferred over
+// "last exit code"; a code of "(never exited)" or "0" is not an exit signal.
+func parseLaunchdState(output string) (state, lastExit string) {
+	var exitCode, exitReason string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if state == "" {
+			if v, ok := strings.CutPrefix(trimmed, "state = "); ok {
+				state = strings.TrimSpace(v)
+				continue
+			}
+		}
+		if v, ok := strings.CutPrefix(trimmed, "last exit reason = "); ok && exitReason == "" {
+			exitReason = strings.TrimSpace(v)
+		}
+		if v, ok := strings.CutPrefix(trimmed, "last exit code = "); ok && exitCode == "" {
+			exitCode = strings.TrimSpace(v)
+		}
+	}
+	switch {
+	case exitReason != "":
+		lastExit = exitReason
+	case exitCode != "" && exitCode != "0" && exitCode != "(never exited)":
+		lastExit = "exit code " + exitCode
+	}
+	return state, lastExit
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/platform/darwin/ -run TestParseLaunchdState -v`
+Expected: PASS (all 5 subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sysext_liveness.go internal/platform/darwin/sysext_liveness_test.go
+git commit -m "feat(#441): parseLaunchdState — first state line + last-exit extraction"
+```
+
+---
+
+### Task 3: `CheckSysExtLiveness` — fail-closed decision table
+
+**Files:**
+- Modify: `internal/platform/darwin/sysext_liveness.go` (append function)
+- Modify: `internal/platform/darwin/sysext_liveness_test.go` (append test)
+
+- [ ] **Step 1: Write the failing test**
+
+First, change the import line at the top of `internal/platform/darwin/sysext_liveness_test.go` from `import "testing"` to:
+
+```go
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+```
+
+Then append to the file:
+
+```go
+func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
+	tests := []struct {
+		name            string
+		sysextOut       string
+		sysextErr       error
+		launchctlOut    string
+		launchctlErr    error
+		wantActivated   bool
+		wantRunning     bool
+		wantProbeFailed bool
+		wantDetailSub   string // Detail must contain this substring
+	}{
+		{
+			name:          "not activated",
+			sysextOut:     sysextListBeaconOnly,
+			wantDetailSub: "not activated",
+		},
+		{
+			name:            "systemextensionsctl fails -> not activated, probe failed",
+			sysextErr:       errors.New("exec: not found"),
+			wantProbeFailed: true,
+			wantDetailSub:   "not activated",
+		},
+		{
+			name:          "activated and running",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  launchdRunning,
+			wantActivated: true,
+			wantRunning:   true,
+			wantDetailSub: "running",
+		},
+		{
+			name:          "activated, spawn scheduled -> not running with diagnostics",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  launchdSpawnScheduled,
+			wantActivated: true,
+			wantRunning:   false,
+			wantDetailSub: "activated but not running (state: spawn scheduled, last exit: exit code 1)",
+		},
+		{
+			name:          "activated, AMFI blocked -> Detail carries OS_REASON_EXEC",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  launchdAMFIBlocked,
+			wantActivated: true,
+			wantRunning:   false,
+			wantDetailSub: "OS_REASON_EXEC",
+		},
+		{
+			name:            "activated, launchctl fails -> fail closed",
+			sysextOut:       sysextListBoth,
+			launchctlErr:    errors.New("Could not find service"),
+			wantActivated:   true,
+			wantRunning:     false,
+			wantProbeFailed: true,
+			wantDetailSub:   "could not be verified",
+		},
+		{
+			name:            "activated, no state line -> fail closed",
+			sysextOut:       sysextListBoth,
+			launchctlOut:    "system/x = {\n\truns = 3\n}\n",
+			wantActivated:   true,
+			wantRunning:     false,
+			wantProbeFailed: true,
+			wantDetailSub:   "could not be verified",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := runLivenessCommand
+			defer func() { runLivenessCommand = restore }()
+			var launchctlLabel string
+			runLivenessCommand = func(name string, args ...string) (string, error) {
+				if name == "systemextensionsctl" {
+					return tt.sysextOut, tt.sysextErr
+				}
+				if name == "launchctl" && len(args) == 2 && args[0] == "print" {
+					launchctlLabel = args[1]
+				}
+				return tt.launchctlOut, tt.launchctlErr
+			}
+
+			got := CheckSysExtLiveness()
+			if got.Activated != tt.wantActivated {
+				t.Errorf("Activated = %v, want %v", got.Activated, tt.wantActivated)
+			}
+			if got.Running != tt.wantRunning {
+				t.Errorf("Running = %v, want %v", got.Running, tt.wantRunning)
+			}
+			if got.ProbeFailed != tt.wantProbeFailed {
+				t.Errorf("ProbeFailed = %v, want %v", got.ProbeFailed, tt.wantProbeFailed)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailSub) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailSub)
+			}
+			if tt.wantActivated && tt.launchctlErr == nil && tt.launchctlOut != "" {
+				want := "system/WCKWMMKJ35." + sysExtBundleID
+				if launchctlLabel != want {
+					t.Errorf("launchctl label = %q, want %q", launchctlLabel, want)
+				}
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/platform/darwin/ -run TestCheckSysExtLiveness -v`
+Expected: FAIL to build with `undefined: CheckSysExtLiveness`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/platform/darwin/sysext_liveness.go`:
+
+```go
+// CheckSysExtLiveness probes whether the agentsh system extension is
+// activated AND its process is actually running. Decision table (fail
+// closed — Running requires positive proof of state = running):
+//
+//	systemextensionsctl        launchctl                      -> result
+//	not activated / cmd fails  (skipped)                      Activated=false, Running=false
+//	activated                  state = running                Running=true
+//	activated                  any other state                Running=false, Detail has state + last exit
+//	activated                  cmd fails / no state / no team Running=false, Detail "could not be verified"
+func CheckSysExtLiveness() SysExtLiveness {
+	out, err := runLivenessCommand("systemextensionsctl", "list")
+	if err != nil {
+		return SysExtLiveness{ProbeFailed: true, Detail: "not activated (systemextensionsctl failed: " + err.Error() + ")"}
+	}
+	activated, teamID := parseSysExtList(out)
+	if !activated {
+		return SysExtLiveness{Detail: "not activated"}
+	}
+
+	liveness := SysExtLiveness{Activated: true}
+	if teamID == "" {
+		liveness.ProbeFailed = true
+		liveness.Detail = "activated but liveness could not be verified (no team ID in systemextensionsctl output)"
+		return liveness
+	}
+
+	label := "system/" + teamID + "." + sysExtBundleID
+	lout, err := runLivenessCommand("launchctl", "print", label)
+	if err != nil {
+		liveness.ProbeFailed = true
+		liveness.Detail = "activated but liveness could not be verified (launchctl print " + label + " failed: " + err.Error() + ")"
+		return liveness
+	}
+
+	state, lastExit := parseLaunchdState(lout)
+	liveness.State = state
+	liveness.LastExit = lastExit
+	switch {
+	case state == "running":
+		liveness.Running = true
+		liveness.Detail = "running"
+	case state == "":
+		liveness.ProbeFailed = true
+		liveness.Detail = "activated but liveness could not be verified (no state in launchctl output)"
+	default:
+		detail := "activated but not running (state: " + state
+		if lastExit != "" {
+			detail += ", last exit: " + lastExit
+		}
+		liveness.Detail = detail + ")"
+	}
+	return liveness
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/platform/darwin/ -run TestCheckSysExtLiveness -v`
+Expected: PASS (all 7 subtests)
+
+- [ ] **Step 5: Run the whole package to catch regressions**
+
+Run: `go test ./internal/platform/darwin/...`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/platform/darwin/sysext_liveness.go internal/platform/darwin/sysext_liveness_test.go
+git commit -m "feat(#441): CheckSysExtLiveness — fail-closed sysext liveness probe"
+```
+
+---
+
+### Task 4: Wire `detect_darwin.go` onto the helper
+
+**Files:**
+- Modify: `internal/capabilities/detect_darwin.go` (delete `checkSysExtInstalled` at lines 110-122; change `Detect()` and `buildDarwinDomains`)
+- Modify: `internal/capabilities/detect_darwin_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `internal/capabilities/detect_darwin_test.go`, add `"strings"` to imports, add the new test, and extend `TestDetect_Darwin`'s `expectedKeys`:
+
+```go
+func TestBuildDarwinDomains_ESFDetail(t *testing.T) {
+	caps := map[string]any{"esf": false, "network_extension": false}
+	detail := "activated but not running (state: spawn scheduled, last exit: exit code 1)"
+	domains := buildDarwinDomains(caps, detail)
+
+	found := 0
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Name != "esf" {
+				continue
+			}
+			found++
+			if b.Available {
+				t.Errorf("domain %q: esf Available = true, want false", d.Name)
+			}
+			if !strings.Contains(b.Detail, "not running") {
+				t.Errorf("domain %q: esf Detail = %q, want liveness detail", d.Name, b.Detail)
+			}
+		}
+	}
+	if found != 2 {
+		t.Errorf("found %d esf backends, want 2 (File Protection, Command Control)", found)
+	}
+}
+```
+
+In `TestDetect_Darwin`, change:
+
+```go
+	expectedKeys := []string{"sandbox_exec", "esf", "esf_activated", "network_extension"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/capabilities/ -run 'TestBuildDarwinDomains_ESFDetail|TestDetect_Darwin' -v`
+Expected: FAIL to build — `buildDarwinDomains` takes 1 argument, and (once building) `esf_activated` key missing.
+
+- [ ] **Step 3: Implement**
+
+In `internal/capabilities/detect_darwin.go`:
+
+1. Replace the imports block (only `checkSysExtInstalled` used `strings`):
+
+```go
+import (
+	"os/exec"
+
+	"github.com/agentsh/agentsh/internal/platform/darwin"
+)
+```
+
+2. Change the signature `func buildDarwinDomains(caps map[string]any) []ProtectionDomain` to:
+
+```go
+func buildDarwinDomains(caps map[string]any, esfDetail string) []ProtectionDomain {
+```
+
+and set `Detail: esfDetail` on BOTH esf backend entries (File Protection line 24, Command Control line 30), replacing `Detail: ""`.
+
+3. In `Detect()`, replace the caps construction and domain build:
+
+```go
+	liveness := darwin.CheckSysExtLiveness()
+	caps := map[string]any{
+		"sandbox_exec":      true,
+		"esf":               liveness.Running,
+		"esf_activated":     liveness.Activated,
+		"network_extension": checkNetworkExtension(),
+		"lima_available":    checkLima(),
+	}
+
+	mode, _ := selectDarwinMode(caps)
+	domains := buildDarwinDomains(caps, liveness.Detail)
+```
+
+4. Delete `checkSysExtInstalled()` entirely (lines 110-122 including the stale "Delegates to the darwin package" comment).
+
+`selectDarwinMode` is untouched — it reads `caps["esf"]`, which is now honest.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/capabilities/ -run 'TestBuildDarwinDomains_ESFDetail|TestDetect_Darwin|TestSelectDarwinMode' -v`
+Expected: PASS. (`TestDetect_Darwin` shells out to the real system — it passes regardless of local sysext state because it only asserts key presence.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/capabilities/detect_darwin.go internal/capabilities/detect_darwin_test.go
+git commit -m "fix(#441): detect gates esf on sysext liveness, not activation"
+```
+
+---
+
+### Task 5: Reason-sensitive esf tips
+
+**Files:**
+- Modify: `internal/capabilities/tips.go` (the `"esf"` entry in `tipsByBackend` ~line 178; the esf entry in `darwinTips` ~line 74)
+- Modify: `internal/capabilities/tips_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/capabilities/tips_test.go` (this file uses testify `assert`):
+
+```go
+func TestLookupTip_ESFReasonSensitive(t *testing.T) {
+	// AMFI rejection: OS_REASON_EXEC must win even though the detail also
+	// contains "not running" (first-match-wins ordering).
+	amfi := lookupTip("esf", `activated but not running (state: spawn scheduled, last exit: OS_REASON_EXEC | Error -413 "No matching profile found")`)
+	assert.NotNil(t, amfi)
+	assert.Contains(t, amfi.Action, "embedded.provisionprofile")
+
+	// Generic not-running: points at launchctl diagnostics.
+	stuck := lookupTip("esf", "activated but not running (state: spawn scheduled, last exit: exit code 1)")
+	assert.NotNil(t, stuck)
+	assert.Contains(t, stuck.Action, "launchctl print")
+	assert.NotContains(t, stuck.Action, "embedded.provisionprofile")
+
+	// Probe failure: liveness unverifiable.
+	unverified := lookupTip("esf", "activated but liveness could not be verified (no state in launchctl output)")
+	assert.NotNil(t, unverified)
+	assert.Contains(t, unverified.Action, "launchctl print")
+
+	// Not installed at all: fallback install tip unchanged.
+	fallback := lookupTip("esf", "not activated")
+	assert.NotNil(t, fallback)
+	assert.Contains(t, fallback.Action, "Install the agentsh macOS app bundle")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/capabilities/ -run TestLookupTip_ESFReasonSensitive -v`
+Expected: FAIL — the current single esf entry returns the install tip for every detail.
+
+- [ ] **Step 3: Implement**
+
+In `tips.go`, replace the `"esf"` entry in `tipsByBackend`:
+
+```go
+	"esf": {
+		{Contains: "OS_REASON_EXEC", Tip: Tip{Feature: "esf", Impact: "Endpoint Security enforcement absent (extension binary rejected at exec)", Action: "macOS refuses to launch the activated extension — likely AMFI/code-signing (e.g. missing embedded.provisionprofile, see #436). Verify the profile inside the .systemextension bundle and reinstall, then check `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt`."}},
+		{Contains: "not running", Tip: Tip{Feature: "esf", Impact: "Endpoint Security enforcement absent (extension activated but not running)", Action: "Inspect `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` for state and last exit reason."}},
+		{Contains: "could not be verified", Tip: Tip{Feature: "esf", Impact: "Endpoint Security liveness unverifiable", Action: "Could not verify the extension process is running. Check it manually: `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt`."}},
+		{Tip: Tip{Feature: "esf", Impact: "Endpoint Security Framework unavailable", Action: "Install the agentsh macOS app bundle with system extension"}},
+	},
+```
+
+Ordering is load-bearing: `OS_REASON_EXEC` before `not running` (a detail can contain both), specific entries before the empty-`Contains` fallback.
+
+Also refresh the legacy `darwinTips` esf entry (consumed only by `GenerateTips`, which has no non-test callers — updated for consistency rather than left stale):
+
+```go
+	{
+		Feature:  "esf",
+		CheckKey: "esf",
+		Impact:   "ESF enforcement unavailable (extension not installed or not running)",
+		Action:   "Install the agentsh macOS app bundle and ensure the system extension is approved and running (see `agentsh detect` detail).",
+	},
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/capabilities/`
+Expected: PASS (includes `TestGenerateTips_Darwin` — if it asserts the old esf `Impact`/`Action` text, update those assertions to the new text as part of this step).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/capabilities/tips.go internal/capabilities/tips_test.go
+git commit -m "feat(#441): reason-sensitive esf tips (AMFI, not-running, unverifiable)"
+```
+
+---
+
+### Task 6: Honest permission tier in `permissions.go`
+
+**Files:**
+- Modify: `internal/platform/darwin/permissions.go`
+- Modify: `internal/platform/darwin/permissions_test.go` (append — this file ALREADY EXISTS with ~205 lines of tests; do NOT overwrite it)
+
+- [ ] **Step 1: Write the failing test**
+
+Append the following functions to the END of the existing `internal/platform/darwin/permissions_test.go`. Its import block already has exactly what these need (`strings`, `testing`) — no import changes. The new names (`TestComputeTier_RequiresRunningSysExt`, `TestComputeMissingPermissions_SysExtBranches`, `findMissing`) don't collide with existing tests, and the existing `TestPermissions_computeMissingPermissions` keeps passing under the new branch logic.
+
+```go
+func TestComputeTier_RequiresRunningSysExt(t *testing.T) {
+	p := &Permissions{HasSystemExtension: true}
+	p.computeTier()
+	if p.Tier != TierEnterprise {
+		t.Errorf("Tier = %v, want TierEnterprise when sysext running", p.Tier)
+	}
+
+	// Activated but not running must NOT reach enterprise tier.
+	p = &Permissions{SysExtActivated: true, HasSystemExtension: false}
+	p.computeTier()
+	if p.Tier == TierEnterprise {
+		t.Error("Tier = TierEnterprise for activated-but-not-running sysext; want lower tier")
+	}
+}
+
+func TestComputeMissingPermissions_SysExtBranches(t *testing.T) {
+	// Not installed: install guidance.
+	p := &Permissions{}
+	p.computeMissingPermissions()
+	mp := findMissing(t, p, "System Extension")
+	if !strings.Contains(mp.HowToEnable, "Install the agentsh macOS app bundle") {
+		t.Errorf("HowToEnable = %q, want install guidance", mp.HowToEnable)
+	}
+
+	// Activated but not running: launchctl diagnostics, not install guidance.
+	p = &Permissions{
+		SysExtActivated: true,
+		SysExtDetail:    "activated but not running (state: spawn scheduled, last exit: exit code 1)",
+	}
+	p.computeMissingPermissions()
+	mp = findMissing(t, p, "System Extension")
+	if !strings.Contains(mp.HowToEnable, "launchctl print") {
+		t.Errorf("HowToEnable = %q, want launchctl diagnostics", mp.HowToEnable)
+	}
+	if !strings.Contains(mp.HowToEnable, p.SysExtDetail) {
+		t.Errorf("HowToEnable = %q, want embedded liveness detail", mp.HowToEnable)
+	}
+}
+
+func findMissing(t *testing.T, p *Permissions, name string) MissingPermission {
+	t.Helper()
+	for _, mp := range p.MissingPermissions {
+		if mp.Name == name {
+			return mp
+		}
+	}
+	t.Fatalf("MissingPermissions has no entry %q", name)
+	return MissingPermission{}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/platform/darwin/ -run 'TestComputeTier_RequiresRunningSysExt|TestComputeMissingPermissions_SysExtBranches' -v`
+Expected: FAIL to build with `unknown field SysExtActivated`
+
+- [ ] **Step 3: Implement**
+
+In `permissions.go`:
+
+1. Extend the struct (after `HasSystemExtension bool`, line 55):
+
+```go
+	HasSystemExtension bool // extension activated AND its process is running
+
+	// SysExtActivated distinguishes "activated but not running" (AMFI-blocked,
+	// crash-looping — see #441) from "not installed at all".
+	SysExtActivated bool
+	SysExtDetail    string
+```
+
+2. In `DetectPermissions()` replace line 89 (`p.HasSystemExtension = CheckSysExtInstalled()`):
+
+```go
+	liveness := CheckSysExtLiveness()
+	p.HasSystemExtension = liveness.Running
+	p.SysExtActivated = liveness.Activated
+	p.SysExtDetail = liveness.Detail
+```
+
+3. Delete `CheckSysExtInstalled()` (lines 104-113; no other callers — verified) and drop `"strings"` from imports if now unused (it is still used by `LogStatus`, so keep it).
+
+4. In `computeMissingPermissions()` replace the sysext block:
+
+```go
+	if !p.HasSystemExtension {
+		mp := MissingPermission{
+			Name:        "System Extension",
+			Description: "ESF-based file/process monitoring and Network Extension filtering",
+			Impact:      "Cannot intercept or block file operations. File monitoring unavailable.",
+			HowToEnable: "Install the agentsh macOS app bundle which includes the system extension.\n" +
+				"After installation, approve it in System Settings > Privacy & Security.",
+			Required: false,
+		}
+		if p.SysExtActivated {
+			mp.Impact = "System extension is activated but its process is not running. ESF enforcement is absent."
+			mp.HowToEnable = "Diagnose with: launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt\n" +
+				"Detected: " + p.SysExtDetail
+		}
+		p.MissingPermissions = append(p.MissingPermissions, mp)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/platform/darwin/ -run 'TestComputeTier|TestComputeMissing' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/permissions.go internal/platform/darwin/permissions_test.go
+git commit -m "fix(#441): enterprise tier requires a running sysext, not merely activated"
+```
+
+---
+
+### Task 7: `SysExtManager.Status()` tells the truth; stub parity
+
+**Files:**
+- Modify: `internal/platform/darwin/sysext.go`
+- Modify: `internal/platform/darwin/sysext_stub.go`
+- Modify: `internal/platform/darwin/sysext_test.go`
+
+- [ ] **Step 1: Update tests first**
+
+In `sysext_test.go`:
+
+1. Delete `TestContains` entirely (the `contains` helper dies in this task).
+2. Extend `TestSysExtStatus_JSONTags` to cover the new fields — replace the struct literal and add assertions:
+
+```go
+	status := SysExtStatus{
+		Installed:   true,
+		Running:     true,
+		State:       "running",
+		LastExit:    "",
+		Version:     "1.0.0",
+		BundleID:    "ai.canyonroad.agentsh.SysExt",
+		ExtensionID: "ext-123",
+		Error:       "",
+	}
+```
+
+and after the existing assertions:
+
+```go
+	if status.State != "running" {
+		t.Error("State mismatch")
+	}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/platform/darwin/ -run TestSysExtStatus_JSONTags -v`
+Expected: FAIL to build with `unknown field State`
+
+- [ ] **Step 3: Implement**
+
+In `sysext.go`:
+
+1. Extend `SysExtStatus`:
+
+```go
+type SysExtStatus struct {
+	Installed   bool   `json:"installed"`
+	Running     bool   `json:"running"`
+	State       string `json:"state,omitempty"`
+	LastExit    string `json:"last_exit,omitempty"`
+	Version     string `json:"version,omitempty"`
+	BundleID    string `json:"bundle_id,omitempty"`
+	ExtensionID string `json:"extension_id,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+```
+
+2. Replace the body of `Status()` after the `m.bundlePath == ""` early return:
+
+```go
+	liveness := CheckSysExtLiveness()
+	status.Installed = liveness.Activated
+	status.Running = liveness.Running
+	status.State = liveness.State
+	status.LastExit = liveness.LastExit
+	if liveness.ProbeFailed || (liveness.Activated && !liveness.Running) {
+		status.Error = liveness.Detail
+	}
+
+	return status, nil
+```
+
+(Cleanly not-activated is a state, not an error — matching the old behavior where absence set no Error. Probe failures and activated-but-not-running do surface via Error, without coupling to Detail string literals.)
+
+3. Delete the now-unused `contains()` helper, and remove `"os/exec"` from the imports — its only use was the `exec.Command("systemextensionsctl", "list")` call this step deletes, so leaving it fails the build with "imported and not used". Keep `"strings"` (`findAppBundle` still uses `strings.Index`).
+
+4. In `sysext_stub.go`, mirror the two new fields in its `SysExtStatus` (identical `State`/`LastExit` lines) for struct parity.
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test ./internal/platform/darwin/...`
+Expected: PASS (note `TestSysExtManager_Status` shells out to the real system; it only asserts BundleID and non-nil status, so it passes in any sysext state)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sysext.go internal/platform/darwin/sysext_stub.go internal/platform/darwin/sysext_test.go
+git commit -m "fix(#441): SysExtStatus.Running reflects real liveness; add State/LastExit"
+```
+
+---
+
+### Task 8: Full verification, live acceptance, PR
+
+**Files:** none (verification + git only)
+
+- [ ] **Step 1: Full build and test suite**
+
+Run: `go build ./... && go test ./...`
+Expected: all packages build, all tests pass
+
+- [ ] **Step 2: Cross-compile gates (CLAUDE.md requirement)**
+
+Run: `GOOS=windows go build ./... && GOOS=linux go build ./...`
+Expected: clean builds (the new file is `//go:build darwin`; stub parity covers `!darwin`)
+
+- [ ] **Step 3: Live acceptance on the dev machine**
+
+Run: `go run ./cmd/agentsh detect -o json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['security_mode'], d['capabilities']['esf'], d['capabilities']['esf_activated'])"`
+
+Expected on the design machine (sysext activated, `spawn scheduled`): security mode is NOT `esf` (falls back to `lima`/`dynamic-seatbelt`/`sandbox-exec`), `esf` is `false`, `esf_activated` is `true`. Also run `go run ./cmd/agentsh detect` (table) and confirm the esf rows show the liveness detail and a tip block mentions `launchctl print`. If the machine's sysext has been repaired since the design session (`launchctl print system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt` shows `state = running`), expect `esf true` instead — verify against actual launchd state, and use the unit fixtures as the source of truth for the broken path.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push -u origin issue-441-esf-liveness-detect
+gh pr create --title "fix(#441): detect gates esf on sysext liveness, not activation" --body "$(cat <<'EOF'
+Fixes #441.
+
+`detect` (and the tier/status surfaces) reported `esf ✓` from `systemextensionsctl list` "activated enabled" alone, so an activated-but-not-running extension (AMFI-blocked #436, launchd-throttled, crash-looping) scored 90 while enforcing nothing.
+
+- New `darwin.CheckSysExtLiveness()`: activation via per-line `systemextensionsctl` parse (+ team ID), liveness via `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` requiring `state = running`; fail-closed on probe failure.
+- `caps["esf"]` = running (honest mode selection + score), new `caps["esf_activated"]` preserves the distinction; esf backends carry the liveness detail.
+- Reason-sensitive tips: `OS_REASON_EXEC` → AMFI/provisionprofile guidance; not-running / unverifiable → launchctl diagnostics.
+- `TierEnterprise` and `SysExtStatus.Running` now require real liveness; `SysExtStatus` gains `State`/`LastExit`.
+
+Spec: docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: File the follow-up issue (spec out-of-scope item)**
+
+```bash
+gh issue create --title "server: report/warn when esf mode is active but the system extension never connects to the policy socket" --body "$(cat <<'EOF'
+Follow-up from #441 (spec: docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md).
+
+#441 makes `detect` verify the sysext *process* is running via launchd state. The remaining gap is functional: the extension is a client that dials into the server's policy socket, so only a running server can know whether enforcement is actually wired end-to-end. The server should surface (log warning and/or status endpoint) when it runs in esf mode and no extension connection is established within a grace period.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Watch CI, then hand off**
+
+Run: `gh pr checks --watch`
+Expected: all green. Per the user's standard workflow: green CI → squash merge → watch main. Confirm with the user before merging.

--- a/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
+++ b/docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md
@@ -349,6 +349,8 @@ git commit -m "feat(#441): parseLaunchdState — first state line + last-exit ex
 
 ### Task 3: `CheckSysExtLiveness` — fail-closed decision table
 
+> **Amended during execution** (see the Task 3 commit): the decision-table test grew to 9 rows with `wantState`/`wantLastExit` columns, single-line/non-empty Detail invariant assertions, and mutation-verified pins on the exact `state == "running"` gate and the blank-team-ID guard. Code deltas: the systemextensionsctl-failure Detail now carries the "could not be verified" token (tips routing), the no-state branch appends `(last exit: …)` when present, timeouts report as `timed out after 5s`, and the branch switch reads `switch state`. The committed code is authoritative over the blocks below.
+
 **Files:**
 - Modify: `internal/platform/darwin/sysext_liveness.go` (append function)
 - Modify: `internal/platform/darwin/sysext_liveness_test.go` (append test)

--- a/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
+++ b/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
@@ -191,6 +191,14 @@ is authoritative):
 4. The no-state-line Detail appends `(last exit: …)` when launchctl output
    carried an exit reason despite lacking a parseable state, so an AMFI
    reason still reaches the tips layer on that path.
+5. `SysExtStatus` diverges from this spec in two deliberate ways: `LastExit`
+   is surfaced only when the process is not running (a historical exit on a
+   healthy service misleads status consumers; trade-off: a crash-looping
+   service that is momentarily running shows no exit history), and the
+   struct gained `ProbeFailed bool` (json `probe_failed`) so status
+   consumers can distinguish "couldn't verify" from "cleanly absent" without
+   substring-matching `Error` — matching the `esf_probe_failed` capability
+   and `Permissions.SysExtProbeFailed`.
 
 ## Out of scope / follow-ups
 

--- a/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
+++ b/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
@@ -171,6 +171,27 @@ old "install the app bundle" wording. `GenerateTips` has no non-test callers
   from `esf ✓ / 90` to `esf ✗` with the launchctl tip and mode falls back to
   `lima`; after the sysext is repaired (`state = running`), `esf ✓` returns.
 
+## Execution amendments
+
+Deltas from this spec adopted during implementation code review (committed code
+is authoritative):
+
+1. `SysExtLiveness` gained a `ProbeFailed bool` field — set on every
+   probe-failure path (command error, missing team ID, unparseable state) so
+   consumers can distinguish "cleanly not activated" from "couldn't verify"
+   without matching Detail string literals.
+2. When `systemextensionsctl` itself fails, Detail is
+   `not activated (liveness could not be verified: systemextensionsctl failed: …)`
+   — carrying the "could not be verified" token so the reason-sensitive tips
+   route to the diagnostics tip instead of the misleading install tip.
+3. `runLivenessCommand` folds captured stderr (whitespace-collapsed to a
+   single line) into returned errors, and reports timeouts as
+   `timed out after 5s` instead of `signal: killed` — Detail stays a
+   one-liner while carrying the tool's actual message.
+4. The no-state-line Detail appends `(last exit: …)` when launchctl output
+   carried an exit reason despite lacking a parseable state, so an AMFI
+   reason still reaches the tips layer on that path.
+
 ## Out of scope / follow-ups
 
 - **Server-side functional check:** report/warn when the server runs in esf

--- a/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
+++ b/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
@@ -1,0 +1,179 @@
+# detect: require sysext liveness before reporting esf (issue #441)
+
+**Date:** 2026-08-05
+**Issue:** [#441](https://github.com/canyonroad/agentsh/issues/441)
+**Prior art:** #388/#390/#392 (Linux seccomp detect honesty), #436/#440 (AMFI-blocked sysext)
+
+## Problem
+
+`agentsh detect` on macOS reports `esf ✓` (and selects the `esf` security mode,
+protection score 90) based solely on `systemextensionsctl list` containing the
+bundle ID and `activated enabled`. It never verifies that the extension
+*process is running*, so any activated-but-not-running condition (AMFI
+rejection, provisioning-profile expiry, cert revocation, launchd throttling)
+reports a healthy sandbox while enforcement is entirely absent. Issue #436 was
+exactly this: every release v0.17.0–v0.20.5 shipped a sysext AMFI refused to
+exec; `detect` said `esf ✓` throughout.
+
+The same activated-equals-working assumption exists in three places:
+
+| Site | Consumes it for |
+|---|---|
+| `internal/capabilities/detect_darwin.go:checkSysExtInstalled` | `caps["esf"]`, mode selection, protection score |
+| `internal/platform/darwin/permissions.go:CheckSysExtInstalled` | `HasSystemExtension` → tier computation (`TierEnterprise`) |
+| `internal/platform/darwin/sysext.go:SysExtManager.Status` | `SysExtStatus.Running` (a field that currently lies) |
+
+Verified live during design: a machine with the sysext `[activated enabled]`
+but `launchctl print` showing `state = spawn scheduled`, `last exit code = 1`,
+and no SysExt process — `detect` reports `esf ✓` there today.
+
+## Decisions made during brainstorming
+
+1. **Scope:** one shared liveness helper in `internal/platform/darwin`; all
+   three call sites collapse onto it.
+2. **Ambiguity policy: fail closed.** `esf` is reported available only on
+   positive proof of liveness (`state = running`). Probe failure (launchctl
+   missing, label not found, unparseable output) → not running, with a Detail
+   explaining that liveness could not be verified. Consistent with the #390
+   precedent: never claim protection you cannot prove.
+3. **Depth: launchd liveness only.** The extension is a *client* that dials
+   into the agentsh server's policy socket, so only a running server can know
+   whether the extension is functionally connected. Server-side connection
+   reporting is out of scope; a follow-up issue will be filed.
+4. **Probe mechanism: parse `launchctl print system/<TeamID>.<bundleID>`**
+   (approach A). Unprivileged (verified), and yields the diagnostics the
+   issue asks for (`state`, `last exit code`, `last exit reason`). Process-
+   enumeration probes were rejected: non-root callers cannot reliably read
+   root-owned process paths/args on macOS, and they yield no diagnostics.
+
+## Design
+
+### Shared helper: `internal/platform/darwin/sysext_liveness.go`
+
+```go
+// SysExtLiveness reports both facts about the system extension separately:
+// whether it is activated (systemextensionsctl) and whether its process is
+// actually running (launchd service state).
+type SysExtLiveness struct {
+    Activated bool   // systemextensionsctl list: row for our bundle ID with "activated enabled"
+    Running   bool   // launchctl print: state = running (positive proof only)
+    State     string // raw launchd state ("running", "spawn scheduled", ""); "" when unknown
+    LastExit  string // "exit code 1", "OS_REASON_EXEC: ...", ""; from launchctl output
+    Detail    string // human-readable one-liner for display and tip matching
+}
+
+func CheckSysExtLiveness() SysExtLiveness
+```
+
+Internally: two pure parsing functions plus a thin, injectable exec layer
+(package-level `runCommand` func var swapped in tests).
+
+1. `parseSysExtList(output string) (activated bool, teamID string)` — scans
+   `systemextensionsctl list` **per line**. Only lines containing the exact
+   bundle-ID token `ai.canyonroad.agentsh.SysExt` count; the team ID is the
+   whitespace-separated token immediately preceding the **first** occurrence
+   of the bundle-ID token (the real row repeats the bundle ID as the display
+   name — `… WCKWMMKJ35 ai.canyonroad.agentsh.SysExt (1.0/14)
+   ai.canyonroad.agentsh.SysExt [activated enabled]` — so matching the last
+   occurrence would yield `(1.0/14)` as the team ID). Any
+   matching row containing `activated enabled` ⇒ activated (upgrade
+   transients can produce multiple rows). Per-line matching also prevents a
+   *different* extension's `activated enabled` (e.g. the co-installed
+   `ai.canyonroad.beacon.sysext`) from satisfying a whole-output substring
+   grep, which is what all three copies do today.
+2. `parseLaunchdState(output string) (state, lastExit string)` — over
+   `launchctl print system/<teamID>.ai.canyonroad.agentsh.SysExt` output,
+   takes the **first** `state = …` line (nested sub-sections contain their
+   own `state = active` lines) and, when present, `last exit code = …` /
+   `last exit reason = …` (reason preferred when both exist).
+
+Decision table (fail closed):
+
+| systemextensionsctl | launchctl | Result |
+|---|---|---|
+| not activated / command fails | skipped | `Activated: false, Running: false`; Detail "not activated" |
+| activated | `state = running` | `Running: true`; Detail "running" |
+| activated | any other state | `Running: false`; Detail `activated but not running (state: <s>, last exit: <e>)` |
+| activated | command fails / label missing / no `state =` line | `Running: false`; Detail `activated but liveness could not be verified (<cause>)` |
+
+Both exec calls use `exec.CommandContext` with a 5-second timeout; timeout ⇒
+probe failure ⇒ fail closed. No hardcoded team ID anywhere (dev-signed builds
+keep working).
+
+Non-darwin builds: the helper is `//go:build darwin`; no new stubs are needed
+because all consumers are darwin-only files.
+
+### Consumer changes
+
+**`internal/capabilities/detect_darwin.go`**
+- `checkSysExtInstalled()` is deleted; `Detect()` calls
+  `darwin.CheckSysExtLiveness()` once (import verified acyclic).
+- `caps["esf"] = liveness.Running` — mode selection (`selectDarwinMode`) and
+  scoring become honest with no logic changes.
+- `caps["esf_activated"] = liveness.Activated` — JSON/YAML output preserves
+  the installed-but-broken distinction.
+- The two esf backend entries in `buildDarwinDomains` (File Protection,
+  Command Control) carry `Detail: liveness.Detail` instead of `""`.
+
+**`internal/capabilities/tips.go`** — `tipsByBackend["esf"]` becomes
+reason-sensitive (first match wins, ordered):
+1. `Contains: "OS_REASON_EXEC"` → binary rejected at exec — likely
+   AMFI/code-signing; verify `embedded.provisionprofile` in the sysext bundle
+   (#436), then reinstall.
+2. `Contains: "not running"` → activated but not running; inspect
+   `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` for state
+   and last exit reason.
+3. `Contains: "could not be verified"` → liveness unverifiable; check the
+   sysext service manually with launchctl.
+4. Fallback (unchanged): install the agentsh macOS app bundle.
+
+Note: the legacy `darwinTips` esf entry consumed by `GenerateTips` keeps the
+old "install the app bundle" wording. `GenerateTips` has no non-test callers
+(production uses `GenerateTipsFromDomains` only); update its esf `Impact`/
+`Action` for consistency rather than leaving stale text behind.
+
+**`internal/platform/darwin/permissions.go`**
+- `HasSystemExtension = CheckSysExtLiveness().Running` — `TierEnterprise` now
+  requires a *working* extension.
+- The `MissingPermissions` entry branches: activated-but-not-running gets
+  `HowToEnable` text pointing at the launchctl diagnostics (embedding the
+  Detail) instead of the misleading "install the app bundle".
+- The local `CheckSysExtInstalled()` is removed in favor of the shared helper.
+
+**`internal/platform/darwin/sysext.go`**
+- `Status()` uses the shared helper: `Installed = Activated`, `Running` is
+  real liveness. `SysExtStatus` gains `State` and `LastExit` fields
+  (`json:",omitempty"`), mirrored in the `//go:build !darwin` copy in
+  `sysext_stub.go` to keep struct parity. The stale "Delegates to the darwin
+  package" comment in detect_darwin.go disappears along with the duplicated
+  code.
+
+## Testing
+
+- **Pure parser tests** (table-driven, real captured fixtures):
+  - current live machine output: activated + `spawn scheduled` +
+    `last exit code = 1` (the false-positive specimen)
+  - synthesized `OS_REASON_EXEC` variant matching the #436 report
+  - `state = running` (healthy)
+  - extension absent; only `ai.canyonroad.beacon.sysext` present
+    (neighbor-collision regression test)
+  - garbage / empty output; missing `state =` line
+  - nested `state = active` lines after the service-level state (first-match)
+- **Decision-table tests** for `CheckSysExtLiveness` with the injected runner,
+  asserting fail-closed on every probe-failure branch (exec error, timeout,
+  label missing, unparseable).
+- **tips_test.go**: new esf reason entries and their precedence
+  (`OS_REASON_EXEC` must match before `not running`).
+- **detect_darwin_test.go**: domains carry the liveness Detail;
+  `esf_activated` present in caps.
+- **Cross-compile gate:** `GOOS=windows go build ./...` (CLAUDE.md).
+- **Live acceptance** (manual, on the design machine): `agentsh detect` flips
+  from `esf ✓ / 90` to `esf ✗` with the launchctl tip and mode falls back to
+  `lima`; after the sysext is repaired (`state = running`), `esf ✓` returns.
+
+## Out of scope / follow-ups
+
+- **Server-side functional check:** report/warn when the server runs in esf
+  mode but the extension never connects to the policy socket (the true
+  end-to-end signal). To be filed as a separate issue.
+- Windows/Linux detect surfaces are untouched.

--- a/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
+++ b/docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md
@@ -199,6 +199,19 @@ is authoritative):
    consumers can distinguish "couldn't verify" from "cleanly absent" without
    substring-matching `Error` — matching the `esf_probe_failed` capability
    and `Permissions.SysExtProbeFailed`.
+6. The tips ordering in this spec (`OS_REASON_EXEC` → `not running` →
+   `could not be verified`) was swapped in the committed code to
+   `OS_REASON_EXEC` → `could not be verified` → `not running`: probe-failure
+   Details fold third-party stderr that can itself contain the words "not
+   running", so our own fixed prefix must match first (pinned by a test).
+   The tip Action texts were also enriched beyond this spec: the not-running
+   tip leads with Full Disk Access (the most common real cause) and a
+   `/usr/bin/log show --predicate 'process == …'` crash-reason command; the
+   AMFI tip carries a concrete `embedded.provisionprofile` check and
+   upgrade-not-reinstall guidance; all `<TeamID>` placeholders resolve via
+   `systemextensionsctl list`. Additionally, the Command Control esf
+   backend's `check_method` JSON value changed from `"entitlement"` to
+   `"sysext"` to reflect how it is actually checked.
 
 ## Out of scope / follow-ups
 

--- a/internal/capabilities/detect_darwin.go
+++ b/internal/capabilities/detect_darwin.go
@@ -4,10 +4,11 @@ package capabilities
 
 import (
 	"os/exec"
-	"strings"
+
+	"github.com/agentsh/agentsh/internal/platform/darwin"
 )
 
-func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
+func buildDarwinDomains(caps map[string]any, esfDetail string) []ProtectionDomain {
 	esf, _ := caps["esf"].(bool)
 	networkExt, _ := caps["network_extension"].(bool)
 	hasMacwrap := checkMacwrap()
@@ -21,13 +22,13 @@ func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
 		{
 			Name: "File Protection", Weight: WeightFileProtection,
 			Backends: []DetectedBackend{
-				{Name: "esf", Available: esf, Detail: "", Description: "Endpoint Security Framework", CheckMethod: "sysext"},
+				{Name: "esf", Available: esf, Detail: esfDetail, Description: "Endpoint Security Framework", CheckMethod: "sysext"},
 			},
 		},
 		{
 			Name: "Command Control", Weight: WeightCommandControl,
 			Backends: []DetectedBackend{
-				{Name: "esf", Available: esf, Detail: "", Description: "process execution control", CheckMethod: "entitlement"},
+				{Name: "esf", Available: esf, Detail: esfDetail, Description: "process execution control", CheckMethod: "sysext"},
 				{Name: "dynamic-seatbelt", Available: hasMacwrap, Detail: macwrapDetail, Description: "policy-driven exec restriction", CheckMethod: "binary"},
 				{Name: "sandbox-exec", Available: true, Detail: "", Description: "macOS sandbox", CheckMethod: "builtin"},
 			},
@@ -70,17 +71,27 @@ func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
 	}
 }
 
-// Detect runs platform-specific detection and returns unified result.
-func Detect() (*DetectResult, error) {
-	caps := map[string]any{
+// darwinCaps maps sysext liveness onto the capability map. Kept pure so the
+// esf/esf_activated mapping — the exact regression #441 fixed — is testable
+// without subprocesses.
+func darwinCaps(l darwin.SysExtLiveness) map[string]any {
+	return map[string]any{
 		"sandbox_exec":      true,
-		"esf":               checkSysExtInstalled(),
+		"esf":               l.Running,
+		"esf_activated":     l.Activated,
+		"esf_probe_failed":  l.ProbeFailed,
 		"network_extension": checkNetworkExtension(),
 		"lima_available":    checkLima(),
 	}
+}
+
+// Detect runs platform-specific detection and returns unified result.
+func Detect() (*DetectResult, error) {
+	liveness := darwin.CheckSysExtLiveness()
+	caps := darwinCaps(liveness)
 
 	mode, _ := selectDarwinMode(caps)
-	domains := buildDarwinDomains(caps)
+	domains := buildDarwinDomains(caps, liveness.Detail)
 	score := ComputeScore(domains)
 
 	var available, unavailable []string
@@ -105,20 +116,6 @@ func Detect() (*DetectResult, error) {
 		Summary:         DetectSummary{Available: available, Unavailable: unavailable},
 		Tips:            tips,
 	}, nil
-}
-
-// checkSysExtInstalled checks if the agentsh system extension is activated.
-// Delegates to the darwin package's exported function.
-func checkSysExtInstalled() bool {
-	// Call the shared detection function from the darwin package
-	cmd := exec.Command("systemextensionsctl", "list")
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	outputStr := string(output)
-	return strings.Contains(outputStr, "ai.canyonroad.agentsh.SysExt") &&
-		strings.Contains(outputStr, "activated enabled")
 }
 
 func checkNetworkExtension() bool {

--- a/internal/capabilities/detect_darwin_test.go
+++ b/internal/capabilities/detect_darwin_test.go
@@ -3,7 +3,10 @@
 package capabilities
 
 import (
+	"strings"
 	"testing"
+
+	darwin "github.com/agentsh/agentsh/internal/platform/darwin"
 )
 
 func TestSelectDarwinMode(t *testing.T) {
@@ -53,7 +56,7 @@ func TestDetect_Darwin(t *testing.T) {
 	}
 
 	// Should have macOS-specific capability keys
-	expectedKeys := []string{"sandbox_exec", "esf", "network_extension"}
+	expectedKeys := []string{"sandbox_exec", "esf", "esf_activated", "esf_probe_failed", "network_extension"}
 	for _, key := range expectedKeys {
 		if _, exists := result.Capabilities[key]; !exists {
 			t.Errorf("Capabilities missing key %q", key)
@@ -63,5 +66,59 @@ func TestDetect_Darwin(t *testing.T) {
 	// sandbox_exec should always be true (built into macOS)
 	if se, ok := result.Capabilities["sandbox_exec"].(bool); !ok || !se {
 		t.Error("sandbox_exec should be true")
+	}
+}
+
+func TestBuildDarwinDomains_ESFDetail(t *testing.T) {
+	caps := map[string]any{"esf": false, "network_extension": false}
+	detail := "activated but not running (state: spawn scheduled, last exit: exit code 1)"
+	domains := buildDarwinDomains(caps, detail)
+
+	found := 0
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Name != "esf" {
+				continue
+			}
+			found++
+			if b.Available {
+				t.Errorf("domain %q: esf Available = true, want false", d.Name)
+			}
+			if !strings.Contains(b.Detail, "not running") {
+				t.Errorf("domain %q: esf Detail = %q, want liveness detail", d.Name, b.Detail)
+			}
+		}
+	}
+	if found != 2 {
+		t.Errorf("found %d esf backends, want 2 (File Protection, Command Control)", found)
+	}
+}
+
+func TestDarwinCaps_LivenessMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		liveness darwin.SysExtLiveness
+		wantESF  bool
+		wantAct  bool
+		wantPF   bool
+	}{
+		{"activated but not running is the #441 case", darwin.SysExtLiveness{Activated: true, Running: false}, false, true, false},
+		{"running implies esf", darwin.SysExtLiveness{Activated: true, Running: true}, true, true, false},
+		{"not activated", darwin.SysExtLiveness{}, false, false, false},
+		{"probe failure surfaces", darwin.SysExtLiveness{Activated: true, ProbeFailed: true}, false, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caps := darwinCaps(tt.liveness)
+			if got := caps["esf"].(bool); got != tt.wantESF {
+				t.Errorf("esf = %v, want %v", got, tt.wantESF)
+			}
+			if got := caps["esf_activated"].(bool); got != tt.wantAct {
+				t.Errorf("esf_activated = %v, want %v", got, tt.wantAct)
+			}
+			if got := caps["esf_probe_failed"].(bool); got != tt.wantPF {
+				t.Errorf("esf_probe_failed = %v, want %v", got, tt.wantPF)
+			}
+		})
 	}
 }

--- a/internal/capabilities/detect_result.go
+++ b/internal/capabilities/detect_result.go
@@ -123,6 +123,11 @@ func (r *DetectResult) Table() string {
 				if detail == "" {
 					detail = " "
 				}
+				if len(detail) > 16 {
+					sb.WriteString(fmt.Sprintf("  %-20s %s  %s\n", b.Name, status, b.Description))
+					sb.WriteString(fmt.Sprintf("  %-20s    %s\n", "", detail))
+					continue
+				}
 				sb.WriteString(fmt.Sprintf("  %-20s %s  %-16s %s\n", b.Name, status, detail, b.Description))
 			}
 			if d.Active != "" && d.Active != "none" {

--- a/internal/capabilities/detect_result_test.go
+++ b/internal/capabilities/detect_result_test.go
@@ -218,6 +218,76 @@ func TestTableFormat_FallbackFlat(t *testing.T) {
 	assert.Contains(t, table, "sandbox_exec")
 }
 
+func TestTable_LongDetailContinuationLine(t *testing.T) {
+	const longDetail = "activated but not running (state: spawn scheduled, last exit: exit code 1)"
+	result := &DetectResult{
+		Platform:        "darwin",
+		SecurityMode:    "esf",
+		ProtectionScore: 70,
+		Domains: []ProtectionDomain{
+			{Name: "Command Control", Weight: 25, Score: 25, Backends: []DetectedBackend{
+				{Name: "esf-exec", Available: true, Detail: "ok", Description: "exec auth"},
+				{Name: "esf-liveness", Available: false, Detail: longDetail, Description: "liveness monitor"},
+			}, Active: "esf-exec"},
+		},
+		Capabilities: map[string]any{"esf": true},
+	}
+
+	table := result.Table()
+	lines := strings.Split(table, "\n")
+
+	// The long detail must appear on a line that does NOT also contain the
+	// Description, i.e. it's rendered on its own continuation line.
+	var longDetailLine string
+	for _, line := range lines {
+		if strings.Contains(line, longDetail) {
+			longDetailLine = line
+			break
+		}
+	}
+	if longDetailLine == "" {
+		t.Fatalf("Table() output does not contain long detail %q:\n%s", longDetail, table)
+	}
+	if strings.Contains(longDetailLine, "liveness monitor") {
+		t.Errorf("long detail line should not also contain Description, got: %q", longDetailLine)
+	}
+
+	// The backend row for the long-detail backend must still contain its
+	// Name, status marker, and Description (just not the detail).
+	var backendRowLine string
+	for _, line := range lines {
+		if strings.Contains(line, "esf-liveness") {
+			backendRowLine = line
+			break
+		}
+	}
+	if backendRowLine == "" {
+		t.Fatalf("Table() output does not contain backend row for esf-liveness:\n%s", table)
+	}
+	if !strings.Contains(backendRowLine, "-") {
+		t.Errorf("backend row should contain unavailable status marker, got: %q", backendRowLine)
+	}
+	if !strings.Contains(backendRowLine, "liveness monitor") {
+		t.Errorf("backend row should contain Description, got: %q", backendRowLine)
+	}
+
+	// The short-detail backend renders inline on one line containing name,
+	// detail, and description.
+	var shortDetailLine string
+	for _, line := range lines {
+		if strings.Contains(line, "esf-exec") {
+			shortDetailLine = line
+			break
+		}
+	}
+	if shortDetailLine == "" {
+		t.Fatalf("Table() output does not contain backend row for esf-exec:\n%s", table)
+	}
+	if !strings.Contains(shortDetailLine, "ok") || !strings.Contains(shortDetailLine, "exec auth") {
+		t.Errorf("short-detail backend row should contain name, detail, and description inline, got: %q", shortDetailLine)
+	}
+}
+
 func TestDetectResult_JSONContainsDomains(t *testing.T) {
 	result := &DetectResult{
 		Platform:        "linux",

--- a/internal/capabilities/tips.go
+++ b/internal/capabilities/tips.go
@@ -74,8 +74,8 @@ var darwinTips = []tipDefinition{
 	{
 		Feature:  "esf",
 		CheckKey: "esf",
-		Impact:   "Using sandbox-exec instead of Endpoint Security",
-		Action:   "Install the agentsh macOS app bundle which includes the system extension.",
+		Impact:   "ESF enforcement unavailable (extension not installed or not running)",
+		Action:   "Install the agentsh macOS app bundle and ensure the system extension is approved and running (see `agentsh detect` detail).",
 	},
 	{
 		Feature:  "lima_available",
@@ -175,7 +175,20 @@ var tipsByBackend = map[string][]reasonTip{
 	"pid-namespace":   {{Tip: Tip{Feature: "pid-namespace", Impact: "Process isolation unavailable", Action: "Run in a PID namespace (docker run --pid=host or unshare -p)"}}},
 	"capability-drop": {{Tip: Tip{Feature: "capability-drop", Impact: "Process retains full Linux capabilities (privilege reduction inactive)", Action: "Start the process with a reduced capability set using systemd CapabilityBoundingSet= + User=, docker run --cap-drop=ALL, or an unprivileged user. Note: capabilities.DropCapabilities() only narrows the bounding set for exec'd children via PR_CAPBSET_DROP and does not lower the running process's permitted/effective sets, so calling it from inside the server is not a substitute for the startup-time mechanisms above."}}},
 	// Darwin
-	"esf":               {{Tip: Tip{Feature: "esf", Impact: "Endpoint Security Framework unavailable", Action: "Install the agentsh macOS app bundle with system extension"}}},
+	// esf: reason-specific entries are order-sensitive — first substring
+	// match wins. OS_REASON_EXEC details can also contain "not running"
+	// and "could not be verified", so it must be checked first; and
+	// probe-failure details embed third-party stderr that can itself
+	// contain "not running", so our own fixed prefix "could not be
+	// verified" is matched before "not running". The empty-Contains
+	// fallback is listed last by convention — lookupTip scans it in a
+	// separate pass, so its position here isn't load-bearing.
+	"esf": {
+		{Contains: "OS_REASON_EXEC", Tip: Tip{Feature: "esf", Impact: "Endpoint Security enforcement absent (extension binary rejected at exec)", Action: "macOS refuses to launch the activated extension — likely AMFI/code-signing. Check the embedded profile: `ls /Library/SystemExtensions/*/ai.canyonroad.agentsh.SysExt.systemextension/Contents/embedded.provisionprofile`. If it is missing, upgrade to a newer agentsh release (older releases shipped without it) — reinstalling the same build fails identically. Full launchd state: `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` (TeamID: `systemextensionsctl list`)."}},
+		{Contains: "could not be verified", Tip: Tip{Feature: "esf", Impact: "Endpoint Security liveness unverifiable", Action: "Could not verify the extension process is running. Check it manually: `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` (TeamID: `systemextensionsctl list`)."}},
+		{Contains: "not running", Tip: Tip{Feature: "esf", Impact: "Endpoint Security enforcement absent (extension activated but not running)", Action: "The extension is installed and approved but its process is not staying up. The most common cause is missing Full Disk Access — grant it under System Settings > Privacy & Security > Full Disk Access. Check the actual crash reason: `/usr/bin/log show --predicate 'process == \"ai.canyonroad.agentsh.SysExt\"' --last 10m`, and `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` for the full launchd state (TeamID: `systemextensionsctl list`)."}},
+		{Tip: Tip{Feature: "esf", Impact: "Endpoint Security Framework unavailable", Action: "Install the agentsh macOS app bundle with system extension"}},
+	},
 	"network-extension": {{Tip: Tip{Feature: "network-extension", Impact: "Network filtering unavailable", Action: "Requires network extension entitlement from Apple"}}},
 	// Windows
 	"winfsp":     {{Tip: Tip{Feature: "winfsp", Impact: "Filesystem interception unavailable", Action: "Install WinFsp: https://winfsp.dev/"}}},

--- a/internal/capabilities/tips_test.go
+++ b/internal/capabilities/tips_test.go
@@ -280,3 +280,49 @@ func TestLookupTip_NonEBPFUnchanged(t *testing.T) {
 	assert.Equal(t, "fuse", tip.Feature)
 	assert.Contains(t, tip.Action, "FUSE3")
 }
+
+func TestLookupTip_ESFReasonSensitive(t *testing.T) {
+	// AMFI rejection: OS_REASON_EXEC must win even though the detail also
+	// contains "not running" (first-match-wins ordering).
+	amfi := lookupTip("esf", `activated but not running (state: spawn scheduled, last exit: OS_REASON_EXEC | Error -413 "No matching profile found")`)
+	assert.NotNil(t, amfi)
+	assert.Contains(t, amfi.Action, "embedded.provisionprofile")
+
+	// AMFI reason surviving a missing state line must still route to the
+	// AMFI tip (detail contains both OS_REASON_EXEC and "could not be
+	// verified"; ordering decides).
+	amfiNoState := lookupTip("esf", "activated but liveness could not be verified (no state in launchctl output) (last exit: OS_REASON_EXEC | Error -413)")
+	assert.NotNil(t, amfiNoState)
+	assert.Contains(t, amfiNoState.Action, "embedded.provisionprofile")
+
+	// Generic not-running: points at launchctl diagnostics.
+	stuck := lookupTip("esf", "activated but not running (state: spawn scheduled, last exit: exit code 1)")
+	assert.NotNil(t, stuck)
+	assert.Contains(t, stuck.Action, "launchctl print")
+	assert.Contains(t, stuck.Action, `/usr/bin/log show --predicate 'process ==`)
+	assert.Contains(t, stuck.Action, "Full Disk Access")
+	assert.NotContains(t, stuck.Action, "embedded.provisionprofile")
+
+	// Probe failure while activated: liveness unverifiable.
+	unverified := lookupTip("esf", "activated but liveness could not be verified (no state in launchctl output)")
+	assert.NotNil(t, unverified)
+	assert.Contains(t, unverified.Action, "launchctl print")
+
+	// Probe failure before activation could be determined: also routes to
+	// the unverifiable tip, NOT the install tip.
+	sysextctlDown := lookupTip("esf", "not activated (liveness could not be verified: systemextensionsctl failed: exit status 1)")
+	assert.NotNil(t, sysextctlDown)
+	assert.Contains(t, sysextctlDown.Action, "launchctl print")
+	assert.NotContains(t, sysextctlDown.Action, "Install the agentsh macOS app bundle")
+
+	// Probe failure whose folded stderr happens to contain "not running" must
+	// still route to the unverifiable tip, not the not-running tip.
+	noisy := lookupTip("esf", "activated but liveness could not be verified (launchctl print system/X failed: exit status 1: service not running)")
+	assert.NotNil(t, noisy)
+	assert.Contains(t, noisy.Impact, "unverifiable")
+
+	// Not installed at all: fallback install tip unchanged.
+	fallback := lookupTip("esf", "not activated")
+	assert.NotNil(t, fallback)
+	assert.Contains(t, fallback.Action, "Install the agentsh macOS app bundle")
+}

--- a/internal/platform/darwin/permissions.go
+++ b/internal/platform/darwin/permissions.go
@@ -52,7 +52,13 @@ func (t PermissionTier) SecurityScore() int {
 
 // Permissions holds detected macOS permission state.
 type Permissions struct {
-	HasSystemExtension bool
+	HasSystemExtension bool // extension activated AND its process is running
+
+	// SysExtActivated distinguishes "activated but not running" (AMFI-blocked,
+	// crash-looping — see #441) from "not installed at all".
+	SysExtActivated   bool
+	SysExtDetail      string
+	SysExtProbeFailed bool
 
 	// Basic Permissions
 	HasRootAccess     bool
@@ -86,7 +92,11 @@ func DetectPermissions() *Permissions {
 	}
 
 	// Check system extension
-	p.HasSystemExtension = CheckSysExtInstalled()
+	liveness := CheckSysExtLiveness()
+	p.HasSystemExtension = liveness.Running
+	p.SysExtActivated = liveness.Activated
+	p.SysExtDetail = liveness.Detail
+	p.SysExtProbeFailed = liveness.ProbeFailed
 
 	// Check basic permissions
 	p.HasRootAccess = os.Geteuid() == 0
@@ -99,17 +109,6 @@ func DetectPermissions() *Permissions {
 	p.computeMissingPermissions()
 
 	return p
-}
-
-// CheckSysExtInstalled checks if the agentsh system extension is installed and activated.
-func CheckSysExtInstalled() bool {
-	cmd := exec.Command("systemextensionsctl", "list")
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return strings.Contains(string(output), "ai.canyonroad.agentsh.SysExt") &&
-		strings.Contains(string(output), "activated enabled")
 }
 
 // checkFullDiskAccess tests if we can access protected directories.
@@ -152,14 +151,25 @@ func (p *Permissions) computeMissingPermissions() {
 	p.MissingPermissions = []MissingPermission{}
 
 	if !p.HasSystemExtension {
-		p.MissingPermissions = append(p.MissingPermissions, MissingPermission{
+		mp := MissingPermission{
 			Name:        "System Extension",
 			Description: "ESF-based file/process monitoring and Network Extension filtering",
 			Impact:      "Cannot intercept or block file operations. File monitoring unavailable.",
 			HowToEnable: "Install the agentsh macOS app bundle which includes the system extension.\n" +
 				"After installation, approve it in System Settings > Privacy & Security.",
 			Required: false,
-		})
+		}
+		switch {
+		case p.SysExtProbeFailed:
+			mp.Impact = "System extension liveness could not be verified. ESF enforcement cannot be confirmed."
+			mp.HowToEnable = "Diagnose with: launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt (TeamID: systemextensionsctl list)\n" +
+				"Detected: " + p.SysExtDetail
+		case p.SysExtActivated:
+			mp.Impact = "System extension is activated but its process is not running. ESF enforcement is absent."
+			mp.HowToEnable = "Diagnose with: launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt (TeamID: systemextensionsctl list)\n" +
+				"Detected: " + p.SysExtDetail
+		}
+		p.MissingPermissions = append(p.MissingPermissions, mp)
 	}
 
 	if !p.HasRootAccess {

--- a/internal/platform/darwin/permissions_test.go
+++ b/internal/platform/darwin/permissions_test.go
@@ -202,3 +202,102 @@ func TestPermissions_LogStatus(t *testing.T) {
 		t.Error("LogStatus() missing System Extension section")
 	}
 }
+
+func TestComputeTier_RequiresRunningSysExt(t *testing.T) {
+	p := &Permissions{HasSystemExtension: true}
+	p.computeTier()
+	if p.Tier != TierEnterprise {
+		t.Errorf("Tier = %v, want TierEnterprise when sysext running", p.Tier)
+	}
+
+	// Activated but not running must NOT reach enterprise tier.
+	p = &Permissions{SysExtActivated: true, HasSystemExtension: false}
+	p.computeTier()
+	if p.Tier == TierEnterprise {
+		t.Error("Tier = TierEnterprise for activated-but-not-running sysext; want lower tier")
+	}
+}
+
+func TestComputeMissingPermissions_SysExtBranches(t *testing.T) {
+	// Not installed: install guidance.
+	p := &Permissions{}
+	p.computeMissingPermissions()
+	mp := findMissing(t, p, "System Extension")
+	if !strings.Contains(mp.HowToEnable, "Install the agentsh macOS app bundle") {
+		t.Errorf("HowToEnable = %q, want install guidance", mp.HowToEnable)
+	}
+
+	// Activated but not running: launchctl diagnostics, not install guidance.
+	p = &Permissions{
+		SysExtActivated: true,
+		SysExtDetail:    "activated but not running (state: spawn scheduled, last exit: exit code 1)",
+	}
+	p.computeMissingPermissions()
+	mp = findMissing(t, p, "System Extension")
+	if !strings.Contains(mp.HowToEnable, "launchctl print") {
+		t.Errorf("HowToEnable = %q, want launchctl diagnostics", mp.HowToEnable)
+	}
+	if !strings.Contains(mp.HowToEnable, p.SysExtDetail) {
+		t.Errorf("HowToEnable = %q, want embedded liveness detail", mp.HowToEnable)
+	}
+}
+
+func findMissing(t *testing.T, p *Permissions, name string) MissingPermission {
+	t.Helper()
+	for _, mp := range p.MissingPermissions {
+		if mp.Name == name {
+			return mp
+		}
+	}
+	t.Fatalf("MissingPermissions has no entry %q", name)
+	return MissingPermission{}
+}
+
+func TestDetectPermissions_SysExtLivenessMapping(t *testing.T) {
+	restore := runLivenessCommand
+	defer func() { runLivenessCommand = restore }()
+
+	cases := []struct {
+		name          string
+		launchctlOut  string
+		wantHasSysExt bool
+	}{
+		{"activated but spawn scheduled must not count", launchdSpawnScheduled, false},
+		{"activated and running counts", launchdRunning, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			runLivenessCommand = func(name string, args ...string) (string, error) {
+				if name == "systemextensionsctl" {
+					return sysextListBoth, nil
+				}
+				return tt.launchctlOut, nil
+			}
+			p := DetectPermissions()
+			if p.HasSystemExtension != tt.wantHasSysExt {
+				t.Errorf("HasSystemExtension = %v, want %v (the #441 mapping)", p.HasSystemExtension, tt.wantHasSysExt)
+			}
+			if !p.SysExtActivated {
+				t.Error("SysExtActivated = false, want true")
+			}
+		})
+	}
+}
+
+func TestComputeMissingPermissions_ProbeFailedBranch(t *testing.T) {
+	p := &Permissions{
+		SysExtProbeFailed: true,
+		SysExtDetail:      "activated but liveness could not be verified (no state in launchctl output)",
+	}
+	p.computeMissingPermissions()
+	mp := findMissing(t, p, "System Extension")
+	if !strings.Contains(mp.Impact, "could not be verified") {
+		t.Errorf("Impact = %q, want unverifiable wording, not a not-running claim", mp.Impact)
+	}
+	if !strings.Contains(mp.HowToEnable, p.SysExtDetail) {
+		t.Errorf("HowToEnable = %q, want embedded detail", mp.HowToEnable)
+	}
+	if strings.Contains(mp.HowToEnable, "Install the agentsh macOS app bundle") {
+		t.Errorf("HowToEnable = %q, must not show install guidance on probe failure", mp.HowToEnable)
+	}
+}

--- a/internal/platform/darwin/sysext.go
+++ b/internal/platform/darwin/sysext.go
@@ -6,15 +6,17 @@ package darwin
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
 // SysExtStatus represents the state of the System Extension.
 type SysExtStatus struct {
-	Installed   bool   `json:"installed"`
-	Running     bool   `json:"running"`
+	Installed   bool   `json:"installed"`              // true once systemextensionsctl reports the extension activated; does not imply Running
+	Running     bool   `json:"running"`                // true only on positive proof the launchd service state is "running"
+	ProbeFailed bool   `json:"probe_failed,omitempty"` // a liveness probe command failed or its output was unparseable
+	State       string `json:"state,omitempty"`        // raw launchd state ("running", "spawn scheduled", ...); "" if unknown
+	LastExit    string `json:"last_exit,omitempty"`    // last recorded launchd exit; suppressed while Running is true
 	Version     string `json:"version,omitempty"`
 	BundleID    string `json:"bundle_id,omitempty"`
 	ExtensionID string `json:"extension_id,omitempty"`
@@ -35,7 +37,7 @@ func NewSysExtManager() *SysExtManager {
 
 	return &SysExtManager{
 		bundlePath: bundlePath,
-		bundleID:   "ai.canyonroad.agentsh.SysExt",
+		bundleID:   sysExtBundleID,
 	}
 }
 
@@ -64,6 +66,18 @@ func findAppBundle(execPath string) string {
 
 // Status returns the current System Extension status.
 // This method never returns an error - any errors are reported via status.Error.
+//
+// The m.bundlePath == "" early return below is a bundle-presence
+// precondition, not a liveness statement: an extension orphaned by app
+// deletion persists in /Library/SystemExtensions and would still report
+// Installed=false here because the .app bundle is gone. Surfaces that need
+// the ground truth regardless of the app bundle call CheckSysExtLiveness
+// directly and do not pass through this gate.
+//
+// Installed reflects activation (systemextensionsctl), not readiness: an
+// extension still awaiting user approval in System Settings reports
+// Installed=false. LastExit is suppressed while Running is true, since a
+// historical exit on an otherwise healthy running service is misleading.
 func (m *SysExtManager) Status() (*SysExtStatus, error) {
 	status := &SysExtStatus{
 		BundleID: m.bundleID,
@@ -74,19 +88,18 @@ func (m *SysExtManager) Status() (*SysExtStatus, error) {
 		return status, nil
 	}
 
-	// Check if extension is installed via systemextensionsctl
-	out, err := exec.Command("systemextensionsctl", "list").Output()
-	if err != nil {
-		status.Error = fmt.Sprintf("systemextensionsctl: %v", err)
-		return status, nil
+	liveness := CheckSysExtLiveness()
+	status.Installed = liveness.Activated
+	status.Running = liveness.Running
+	status.ProbeFailed = liveness.ProbeFailed
+	status.State = liveness.State
+	if !liveness.Running {
+		// A historical exit on a healthy running service is misleading in
+		// status output; surface it only when the process is not up.
+		status.LastExit = liveness.LastExit
 	}
-
-	output := string(out)
-	if contains(output, m.bundleID) {
-		status.Installed = true
-		if contains(output, "activated enabled") {
-			status.Running = true
-		}
+	if liveness.ProbeFailed || (liveness.Activated && !liveness.Running) {
+		status.Error = liveness.Detail
 	}
 
 	return status, nil
@@ -121,21 +134,4 @@ func (m *SysExtManager) Activate() (ActivateResult, error) {
 // Uninstall removes the System Extension.
 func (m *SysExtManager) Uninstall() error {
 	return fmt.Errorf("not implemented: requires Swift integration")
-}
-
-// contains checks if substr is present in s.
-// Handles empty strings safely.
-func contains(s, substr string) bool {
-	if len(substr) == 0 {
-		return true
-	}
-	if len(s) < len(substr) {
-		return false
-	}
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/platform/darwin/sysext_activate_cgo.go
+++ b/internal/platform/darwin/sysext_activate_cgo.go
@@ -112,8 +112,6 @@ const (
 	ActivateFailed ActivateResult = -1
 )
 
-const sysExtBundleID = "ai.canyonroad.agentsh.SysExt"
-
 // activateExtension calls OSSystemExtensionManager to activate the system extension.
 // This blocks until the request completes or the system indicates user approval is needed.
 func activateExtension() (ActivateResult, error) {

--- a/internal/platform/darwin/sysext_liveness.go
+++ b/internal/platform/darwin/sysext_liveness.go
@@ -40,10 +40,14 @@ var runLivenessCommand = func(name string, args ...string) (string, error) {
 	defer cancel()
 	out, err := exec.CommandContext(ctx, name, args...).Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			if msg := strings.Join(strings.Fields(string(exitErr.Stderr)), " "); msg != "" {
-				err = fmt.Errorf("%w: %s", err, msg)
+		if ctx.Err() != nil {
+			err = fmt.Errorf("timed out after %v", livenessCmdTimeout)
+		} else {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				if msg := strings.Join(strings.Fields(string(exitErr.Stderr)), " "); msg != "" {
+					err = fmt.Errorf("%w: %s", err, msg)
+				}
 			}
 		}
 	}
@@ -115,4 +119,61 @@ func parseLaunchdState(output string) (state, lastExit string) {
 		lastExit = "exit code " + exitCode
 	}
 	return state, lastExit
+}
+
+// CheckSysExtLiveness probes whether the agentsh system extension is
+// activated AND its process is actually running. Decision table (fail
+// closed — Running requires positive proof of state = running):
+//
+//	systemextensionsctl        launchctl                      -> result
+//	not activated / cmd fails  (skipped)                      Activated=false, Running=false
+//	activated                  state = running                Running=true
+//	activated                  any other state                Running=false, Detail has state + last exit
+//	activated                  cmd fails / no state / no team  Running=false, Detail "could not be verified"
+func CheckSysExtLiveness() SysExtLiveness {
+	out, err := runLivenessCommand("systemextensionsctl", "list")
+	if err != nil {
+		return SysExtLiveness{ProbeFailed: true, Detail: "not activated (liveness could not be verified: systemextensionsctl failed: " + err.Error() + ")"}
+	}
+	activated, teamID := parseSysExtList(out)
+	if !activated {
+		return SysExtLiveness{Detail: "not activated"}
+	}
+
+	liveness := SysExtLiveness{Activated: true}
+	if teamID == "" {
+		liveness.ProbeFailed = true
+		liveness.Detail = "activated but liveness could not be verified (no team ID in systemextensionsctl output)"
+		return liveness
+	}
+
+	label := "system/" + teamID + "." + sysExtBundleID
+	lout, err := runLivenessCommand("launchctl", "print", label)
+	if err != nil {
+		liveness.ProbeFailed = true
+		liveness.Detail = "activated but liveness could not be verified (launchctl print " + label + " failed: " + err.Error() + ")"
+		return liveness
+	}
+
+	state, lastExit := parseLaunchdState(lout)
+	liveness.State = state
+	liveness.LastExit = lastExit
+	switch state {
+	case "running":
+		liveness.Running = true
+		liveness.Detail = "running"
+	case "":
+		liveness.ProbeFailed = true
+		liveness.Detail = "activated but liveness could not be verified (no state in launchctl output)"
+		if lastExit != "" {
+			liveness.Detail += " (last exit: " + lastExit + ")"
+		}
+	default:
+		detail := "activated but not running (state: " + state
+		if lastExit != "" {
+			detail += ", last exit: " + lastExit
+		}
+		liveness.Detail = detail + ")"
+	}
+	return liveness
 }

--- a/internal/platform/darwin/sysext_liveness.go
+++ b/internal/platform/darwin/sysext_liveness.go
@@ -82,3 +82,37 @@ func parseSysExtList(output string) (activated bool, teamID string) {
 	}
 	return activated, teamID
 }
+
+// parseLaunchdState extracts the service-level state and last-exit info from
+// `launchctl print system/<label>` output. Only the FIRST "state =" line is
+// the service state: nested sub-sections (event triggers, XPC endpoints)
+// contain their own "state = active" lines. "last exit reason" (present on
+// exec-level failures like AMFI rejection, per #436) is preferred over
+// "last exit code"; a code of "(never exited)" or "0" is not an exit signal.
+// The reported last exit is the most recent exit launchd ever recorded for
+// the service and may predate the current state.
+func parseLaunchdState(output string) (state, lastExit string) {
+	var exitCode, exitReason string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if state == "" {
+			if v, ok := strings.CutPrefix(trimmed, "state = "); ok {
+				state = strings.TrimSpace(v)
+				continue
+			}
+		}
+		if v, ok := strings.CutPrefix(trimmed, "last exit reason = "); ok && exitReason == "" {
+			exitReason = strings.TrimSpace(v)
+		}
+		if v, ok := strings.CutPrefix(trimmed, "last exit code = "); ok && exitCode == "" {
+			exitCode = strings.TrimSpace(v)
+		}
+	}
+	switch {
+	case exitReason != "":
+		lastExit = exitReason
+	case exitCode != "" && exitCode != "0" && exitCode != "(never exited)":
+		lastExit = "exit code " + exitCode
+	}
+	return state, lastExit
+}

--- a/internal/platform/darwin/sysext_liveness.go
+++ b/internal/platform/darwin/sysext_liveness.go
@@ -1,0 +1,84 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	sysExtBundleID     = "ai.canyonroad.agentsh.SysExt"
+	livenessCmdTimeout = 5 * time.Second
+)
+
+// SysExtLiveness reports two separate facts about the system extension:
+// whether it is activated (systemextensionsctl) and whether its process is
+// actually running (launchd service state). Running is set only on positive
+// proof (state = running); every probe failure fails closed (issue #441 —
+// an activated-but-AMFI-blocked extension must not report as healthy).
+type SysExtLiveness struct {
+	Activated   bool   // systemextensionsctl row for our bundle ID says "activated enabled"
+	Running     bool   // launchctl service state is "running"
+	ProbeFailed bool   // a probe command failed or its output was unparseable (Running stays false)
+	State       string // raw launchd state ("running", "spawn scheduled", ...); "" if unknown
+	LastExit    string // "exit code 1", "OS_REASON_EXEC ...", ...; "" if none
+	Detail      string // human-readable one-liner; tips.go matches substrings of this
+}
+
+// runLivenessCommand executes a probe command with a timeout. Package-level
+// var so tests can inject fixture output (tests swapping it must not use
+// t.Parallel()). Captured stderr is collapsed to a single line before being
+// folded into the returned error, so probe failures carry the tool's actual
+// message while Detail stays a one-liner.
+var runLivenessCommand = func(name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), livenessCmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if msg := strings.Join(strings.Fields(string(exitErr.Stderr)), " "); msg != "" {
+				err = fmt.Errorf("%w: %s", err, msg)
+			}
+		}
+	}
+	return string(out), err
+}
+
+// parseSysExtList scans systemextensionsctl list output line by line for an
+// "activated enabled" row whose fields contain the exact bundle-ID token
+// (the row repeats the bundle ID as its display name, so the team ID is the
+// field immediately preceding the FIRST occurrence; matching the last would
+// return the version column). Exact-token matching prevents both a different
+// extension's "activated enabled" row and a prefix-sibling bundle ID (e.g. a
+// future ...SysExtBeta) from satisfying the check, and scanning continues
+// past rows that yield no team ID so a transient extra row cannot mask a
+// healthy one. A "*" in the preceding field is the `active` column marker of
+// a blank team-ID row, not a team ID.
+func parseSysExtList(output string) (activated bool, teamID string) {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "activated enabled") {
+			continue
+		}
+		fields := strings.Fields(line)
+		for i, f := range fields {
+			if f != sysExtBundleID {
+				continue
+			}
+			activated = true
+			if i > 0 && fields[i-1] != "*" {
+				teamID = fields[i-1]
+			}
+			break
+		}
+		if activated && teamID != "" {
+			return true, teamID
+		}
+	}
+	return activated, teamID
+}

--- a/internal/platform/darwin/sysext_liveness_test.go
+++ b/internal/platform/darwin/sysext_liveness_test.go
@@ -89,3 +89,81 @@ func TestParseSysExtList(t *testing.T) {
 		})
 	}
 }
+
+// Trimmed real output (2026-08-05) from the #441 specimen machine. The
+// nested "state = active" lines below the top-level state are real — the
+// parser must take only the FIRST "state =" line.
+const launchdSpawnScheduled = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 0
+	path = (submitted by smd[532])
+	type = Submitted
+	state = spawn scheduled
+
+	program = /Library/SystemExtensions/0FED1DDB-30D3-4AAD-A31C-8E7F1229868E/ai.canyonroad.agentsh.SysExt.systemextension/Contents/MacOS/ai.canyonroad.agentsh.SysExt
+	domain = system
+	minimum runtime = 10
+	exit timeout = 5
+	runs = 199773
+	last exit code = 1
+
+	event triggers = {
+		ai.canyonroad.agentsh.SysExt => {
+			state = active
+		}
+		ai.canyonroad.agentsh.SysExt.esf => {
+			state = active
+		}
+	}
+}
+`
+
+const launchdRunning = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 1
+	path = (submitted by smd[532])
+	type = Submitted
+	state = running
+
+	program = /Library/SystemExtensions/0FED1DDB-30D3-4AAD-A31C-8E7F1229868E/ai.canyonroad.agentsh.SysExt.systemextension/Contents/MacOS/ai.canyonroad.agentsh.SysExt
+	pid = 4242
+	domain = system
+	runs = 1
+	last exit code = (never exited)
+}
+`
+
+// Synthesized from the #436 report (AMFI rejects the binary at exec).
+const launchdAMFIBlocked = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 0
+	state = spawn scheduled
+	runs = 324
+	last exit reason = OS_REASON_EXEC | Error -413 "No matching profile found"
+	last exit code = (never exited)
+}
+`
+
+func TestParseLaunchdState(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		wantState    string
+		wantLastExit string
+	}{
+		{"spawn scheduled with exit code", launchdSpawnScheduled, "spawn scheduled", "exit code 1"},
+		{"running, never exited suppressed", launchdRunning, "running", ""},
+		{"amfi blocked reason preferred over code", launchdAMFIBlocked, "spawn scheduled", `OS_REASON_EXEC | Error -413 "No matching profile found"`},
+		{"no state line", "system/x = {\n\truns = 3\n}\n", "", ""},
+		{"empty output", "", "", ""},
+		{"exit code 0 suppressed", "system/x = {\n\tstate = not running\n\tlast exit code = 0\n}\n", "not running", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, lastExit := parseLaunchdState(tt.output)
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			if lastExit != tt.wantLastExit {
+				t.Errorf("lastExit = %q, want %q", lastExit, tt.wantLastExit)
+			}
+		})
+	}
+}

--- a/internal/platform/darwin/sysext_liveness_test.go
+++ b/internal/platform/darwin/sysext_liveness_test.go
@@ -2,7 +2,11 @@
 
 package darwin
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 // Real output captured 2026-08-05 from a machine where the agentsh sysext is
 // activated but AMFI/launchd keeps it from running (the #441 specimen). Note
@@ -163,6 +167,154 @@ func TestParseLaunchdState(t *testing.T) {
 			}
 			if lastExit != tt.wantLastExit {
 				t.Errorf("lastExit = %q, want %q", lastExit, tt.wantLastExit)
+			}
+		})
+	}
+}
+
+func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
+	tests := []struct {
+		name            string
+		sysextOut       string
+		sysextErr       error
+		launchctlOut    string
+		launchctlErr    error
+		wantActivated   bool
+		wantRunning     bool
+		wantProbeFailed bool
+		wantState       string
+		wantLastExit    string
+		wantDetailSub   string // Detail must contain this substring
+	}{
+		{
+			name:          "not activated",
+			sysextOut:     sysextListBeaconOnly,
+			wantDetailSub: "not activated",
+		},
+		{
+			name:            "systemextensionsctl fails -> not activated, probe failed",
+			sysextErr:       errors.New("exec: not found"),
+			wantProbeFailed: true,
+			wantDetailSub:   "not activated",
+		},
+		{
+			name:          "activated and running",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  launchdRunning,
+			wantActivated: true,
+			wantRunning:   true,
+			wantState:     "running",
+			wantLastExit:  "",
+			wantDetailSub: "running",
+		},
+		{
+			name:          "activated, spawn scheduled -> not running with diagnostics",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  launchdSpawnScheduled,
+			wantActivated: true,
+			wantRunning:   false,
+			wantState:     "spawn scheduled",
+			wantLastExit:  "exit code 1",
+			wantDetailSub: "activated but not running (state: spawn scheduled, last exit: exit code 1)",
+		},
+		{
+			name:          "activated, AMFI blocked -> Detail carries OS_REASON_EXEC",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  launchdAMFIBlocked,
+			wantActivated: true,
+			wantRunning:   false,
+			wantState:     "spawn scheduled",
+			wantLastExit:  `OS_REASON_EXEC | Error -413 "No matching profile found"`,
+			wantDetailSub: "OS_REASON_EXEC",
+		},
+		{
+			name:            "activated, launchctl fails -> fail closed",
+			sysextOut:       sysextListBoth,
+			launchctlErr:    errors.New("Could not find service"),
+			wantActivated:   true,
+			wantRunning:     false,
+			wantProbeFailed: true,
+			wantDetailSub:   "could not be verified",
+		},
+		{
+			name:            "activated, no state line -> fail closed",
+			sysextOut:       sysextListBoth,
+			launchctlOut:    "system/x = {\n\truns = 3\n}\n",
+			wantActivated:   true,
+			wantRunning:     false,
+			wantProbeFailed: true,
+			wantState:       "",
+			wantLastExit:    "",
+			wantDetailSub:   "could not be verified",
+		},
+		{
+			name:          "launchd state 'not running' must not satisfy the gate",
+			sysextOut:     sysextListBoth,
+			launchctlOut:  "system/x = {\n\tstate = not running\n\tlast exit code = 1\n}\n",
+			wantActivated: true,
+			wantRunning:   false,
+			wantState:     "not running",
+			wantLastExit:  "exit code 1",
+			wantDetailSub: "activated but not running (state: not running, last exit: exit code 1)",
+		},
+		{
+			name:            "activated but blank team ID -> fail closed, launchctl skipped",
+			sysextOut:       sysextListBlankTeamID,
+			launchctlOut:    launchdRunning, // must be ignored; if reached, Running would flip true
+			wantActivated:   true,
+			wantRunning:     false,
+			wantProbeFailed: true,
+			wantDetailSub:   "could not be verified",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := runLivenessCommand
+			defer func() { runLivenessCommand = restore }()
+			var launchctlLabel string
+			runLivenessCommand = func(name string, args ...string) (string, error) {
+				if name == "systemextensionsctl" {
+					return tt.sysextOut, tt.sysextErr
+				}
+				if name == "launchctl" && len(args) == 2 && args[0] == "print" {
+					launchctlLabel = args[1]
+				}
+				return tt.launchctlOut, tt.launchctlErr
+			}
+
+			got := CheckSysExtLiveness()
+			if got.Activated != tt.wantActivated {
+				t.Errorf("Activated = %v, want %v", got.Activated, tt.wantActivated)
+			}
+			if got.Running != tt.wantRunning {
+				t.Errorf("Running = %v, want %v", got.Running, tt.wantRunning)
+			}
+			if got.ProbeFailed != tt.wantProbeFailed {
+				t.Errorf("ProbeFailed = %v, want %v", got.ProbeFailed, tt.wantProbeFailed)
+			}
+			if got.State != tt.wantState {
+				t.Errorf("State = %q, want %q", got.State, tt.wantState)
+			}
+			if got.LastExit != tt.wantLastExit {
+				t.Errorf("LastExit = %q, want %q", got.LastExit, tt.wantLastExit)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailSub) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailSub)
+			}
+			if strings.ContainsAny(got.Detail, "\n\r") {
+				t.Errorf("Detail must be a single line for the table renderer, got %q", got.Detail)
+			}
+			if got.Detail == "" {
+				t.Errorf("Detail must never be empty")
+			}
+			if tt.wantRunning && got.Detail != "running" {
+				t.Errorf("healthy Detail = %q, want exactly \"running\"", got.Detail)
+			}
+			if tt.wantActivated && tt.launchctlErr == nil && tt.launchctlOut != "" && launchctlLabel != "" {
+				want := "system/WCKWMMKJ35." + sysExtBundleID
+				if launchctlLabel != want {
+					t.Errorf("launchctl label = %q, want %q", launchctlLabel, want)
+				}
 			}
 		})
 	}

--- a/internal/platform/darwin/sysext_liveness_test.go
+++ b/internal/platform/darwin/sysext_liveness_test.go
@@ -174,17 +174,18 @@ func TestParseLaunchdState(t *testing.T) {
 
 func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
 	tests := []struct {
-		name            string
-		sysextOut       string
-		sysextErr       error
-		launchctlOut    string
-		launchctlErr    error
-		wantActivated   bool
-		wantRunning     bool
-		wantProbeFailed bool
-		wantState       string
-		wantLastExit    string
-		wantDetailSub   string // Detail must contain this substring
+		name                 string
+		sysextOut            string
+		sysextErr            error
+		launchctlOut         string
+		launchctlErr         error
+		wantActivated        bool
+		wantRunning          bool
+		wantProbeFailed      bool
+		wantState            string
+		wantLastExit         string
+		wantDetailSub        string // Detail must contain this substring
+		wantLaunchctlSkipped bool
 	}{
 		{
 			name:          "not activated",
@@ -195,7 +196,7 @@ func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
 			name:            "systemextensionsctl fails -> not activated, probe failed",
 			sysextErr:       errors.New("exec: not found"),
 			wantProbeFailed: true,
-			wantDetailSub:   "not activated",
+			wantDetailSub:   "not activated (liveness could not be verified",
 		},
 		{
 			name:          "activated and running",
@@ -258,13 +259,24 @@ func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
 			wantDetailSub: "activated but not running (state: not running, last exit: exit code 1)",
 		},
 		{
-			name:            "activated but blank team ID -> fail closed, launchctl skipped",
-			sysextOut:       sysextListBlankTeamID,
-			launchctlOut:    launchdRunning, // must be ignored; if reached, Running would flip true
+			name:                 "activated but blank team ID -> fail closed, launchctl skipped",
+			sysextOut:            sysextListBlankTeamID,
+			launchctlOut:         launchdRunning, // must be ignored; if reached, Running would flip true
+			wantActivated:        true,
+			wantRunning:          false,
+			wantProbeFailed:      true,
+			wantDetailSub:        "could not be verified",
+			wantLaunchctlSkipped: true,
+		},
+		{
+			name:            "no state but AMFI reason still surfaces",
+			sysextOut:       sysextListBoth,
+			launchctlOut:    "system/x = {\n\tlast exit reason = OS_REASON_EXEC | Error -413\n}\n",
 			wantActivated:   true,
 			wantRunning:     false,
 			wantProbeFailed: true,
-			wantDetailSub:   "could not be verified",
+			wantLastExit:    "OS_REASON_EXEC | Error -413",
+			wantDetailSub:   "could not be verified (no state in launchctl output) (last exit: OS_REASON_EXEC | Error -413)",
 		},
 	}
 	for _, tt := range tests {
@@ -276,8 +288,8 @@ func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
 				if name == "systemextensionsctl" {
 					return tt.sysextOut, tt.sysextErr
 				}
-				if name == "launchctl" && len(args) == 2 && args[0] == "print" {
-					launchctlLabel = args[1]
+				if name == "launchctl" {
+					launchctlLabel = strings.Join(args, " ")
 				}
 				return tt.launchctlOut, tt.launchctlErr
 			}
@@ -310,11 +322,12 @@ func TestCheckSysExtLiveness_DecisionTable(t *testing.T) {
 			if tt.wantRunning && got.Detail != "running" {
 				t.Errorf("healthy Detail = %q, want exactly \"running\"", got.Detail)
 			}
-			if tt.wantActivated && tt.launchctlErr == nil && tt.launchctlOut != "" && launchctlLabel != "" {
-				want := "system/WCKWMMKJ35." + sysExtBundleID
-				if launchctlLabel != want {
-					t.Errorf("launchctl label = %q, want %q", launchctlLabel, want)
-				}
+			wantCall := ""
+			if tt.wantActivated && !tt.wantLaunchctlSkipped {
+				wantCall = "print system/WCKWMMKJ35." + sysExtBundleID
+			}
+			if launchctlLabel != wantCall {
+				t.Errorf("launchctl invocation = %q, want %q", launchctlLabel, wantCall)
 			}
 		})
 	}

--- a/internal/platform/darwin/sysext_liveness_test.go
+++ b/internal/platform/darwin/sysext_liveness_test.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package darwin
+
+import "testing"
+
+// Real output captured 2026-08-05 from a machine where the agentsh sysext is
+// activated but AMFI/launchd keeps it from running (the #441 specimen). Note
+// the co-installed beacon extension: whole-output substring matching would
+// false-positive on it.
+const sysextListBoth = `2 extension(s)
+--- com.apple.system_extension.endpoint_security (Go to 'System Settings > General > Login Items & Extensions > Endpoint Security Extensions' to modify these system extension(s))
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]
+*	*	WCKWMMKJ35	ai.canyonroad.beacon.sysext (0.1.0/1781653639)	Beacon System Extension	[activated enabled]
+`
+
+const sysextListBeaconOnly = `1 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*	WCKWMMKJ35	ai.canyonroad.beacon.sysext (0.1.0/1781653639)	Beacon System Extension	[activated enabled]
+`
+
+const sysextListWaiting = `1 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+		WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated waiting for user]
+`
+
+// Upgrade transient: old version terminating, new one activated enabled.
+const sysextListUpgrade = `2 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+		WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/13)	ai.canyonroad.agentsh.SysExt	[terminated waiting to uninstall on reboot]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]
+`
+
+// A hypothetical prefix-sibling extension: must NOT match our exact token.
+const sysextListPrefixSibling = `1 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExtBeta (1.0/2)	ai.canyonroad.agentsh.SysExtBeta	[activated enabled]
+`
+
+// Prefix-sibling row ABOVE the real row: real row must still win with its team ID.
+const sysextListSiblingBeforeReal = `2 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExtBeta (1.0/2)	ai.canyonroad.agentsh.SysExtBeta	[activated enabled]
+*	*	WCKWMMKJ35	ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]
+`
+
+// Blank team-ID column (possible under `systemextensionsctl developer on`):
+// consecutive tabs mean strings.Fields sees `*`, `*`, then the bundle ID, so
+// the "*" guard must keep teamID empty rather than returning the active-
+// column marker.
+const sysextListBlankTeamID = `1 extension(s)
+--- com.apple.system_extension.endpoint_security
+enabled	active	teamID	bundleID (version)	name	[state]
+*	*		ai.canyonroad.agentsh.SysExt (1.0/14)	ai.canyonroad.agentsh.SysExt	[activated enabled]
+`
+
+func TestParseSysExtList(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		wantActivated bool
+		wantTeamID    string
+	}{
+		{"activated with neighbor extension", sysextListBoth, true, "WCKWMMKJ35"},
+		{"neighbor only must not match", sysextListBeaconOnly, false, ""},
+		{"waiting for user is not activated", sysextListWaiting, false, ""},
+		{"upgrade transient finds enabled row", sysextListUpgrade, true, "WCKWMMKJ35"},
+		{"empty output", "", false, ""},
+		{"garbage output", "no extensions here\njust noise\n", false, ""},
+		{"prefix sibling must not match", sysextListPrefixSibling, false, ""},
+		{"sibling row before real row", sysextListSiblingBeforeReal, true, "WCKWMMKJ35"},
+		{"blank team ID column yields empty not asterisk", sysextListBlankTeamID, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			activated, teamID := parseSysExtList(tt.output)
+			if activated != tt.wantActivated {
+				t.Errorf("activated = %v, want %v", activated, tt.wantActivated)
+			}
+			if teamID != tt.wantTeamID {
+				t.Errorf("teamID = %q, want %q", teamID, tt.wantTeamID)
+			}
+		})
+	}
+}

--- a/internal/platform/darwin/sysext_stub.go
+++ b/internal/platform/darwin/sysext_stub.go
@@ -7,8 +7,11 @@ import "fmt"
 
 // SysExtStatus represents the state of the System Extension.
 type SysExtStatus struct {
-	Installed   bool   `json:"installed"`
-	Running     bool   `json:"running"`
+	Installed   bool   `json:"installed"`              // true once systemextensionsctl reports the extension activated; does not imply Running
+	Running     bool   `json:"running"`                // true only on positive proof the launchd service state is "running"
+	ProbeFailed bool   `json:"probe_failed,omitempty"` // a liveness probe command failed or its output was unparseable
+	State       string `json:"state,omitempty"`        // raw launchd state ("running", "spawn scheduled", ...); "" if unknown
+	LastExit    string `json:"last_exit,omitempty"`    // last recorded launchd exit; suppressed while Running is true
 	Version     string `json:"version,omitempty"`
 	BundleID    string `json:"bundle_id,omitempty"`
 	ExtensionID string `json:"extension_id,omitempty"`

--- a/internal/platform/darwin/sysext_test.go
+++ b/internal/platform/darwin/sysext_test.go
@@ -3,8 +3,21 @@
 package darwin
 
 import (
+	"errors"
+	"strings"
 	"testing"
 )
+
+// state = running while launchd still remembers an older crash (runs > 1).
+const launchdRunningAfterCrash = `system/WCKWMMKJ35.ai.canyonroad.agentsh.SysExt = {
+	active count = 1
+	state = running
+
+	pid = 4242
+	runs = 199773
+	last exit code = 1
+}
+`
 
 func TestNewSysExtManager(t *testing.T) {
 	m := NewSysExtManager()
@@ -96,96 +109,13 @@ func TestFindAppBundle_FromWithinBundle(t *testing.T) {
 	}
 }
 
-func TestContains(t *testing.T) {
-	tests := []struct {
-		name   string
-		s      string
-		substr string
-		want   bool
-	}{
-		{
-			name:   "empty string and empty substr",
-			s:      "",
-			substr: "",
-			want:   true,
-		},
-		{
-			name:   "empty string with non-empty substr",
-			s:      "",
-			substr: "foo",
-			want:   false,
-		},
-		{
-			name:   "non-empty string with empty substr",
-			s:      "foo",
-			substr: "",
-			want:   true,
-		},
-		{
-			name:   "substr at start",
-			s:      "hello world",
-			substr: "hello",
-			want:   true,
-		},
-		{
-			name:   "substr at end",
-			s:      "hello world",
-			substr: "world",
-			want:   true,
-		},
-		{
-			name:   "substr in middle",
-			s:      "hello world",
-			substr: "lo wo",
-			want:   true,
-		},
-		{
-			name:   "substr not present",
-			s:      "hello world",
-			substr: "foo",
-			want:   false,
-		},
-		{
-			name:   "substr longer than string",
-			s:      "hi",
-			substr: "hello",
-			want:   false,
-		},
-		{
-			name:   "exact match",
-			s:      "hello",
-			substr: "hello",
-			want:   true,
-		},
-		{
-			name:   "real systemextensionsctl output with bundle ID",
-			s:      "1 extension(s)\n--- com.apple.system_extension.endpoint_security\nai.canyonroad.agentsh.SysExt	team_id	activated enabled",
-			substr: "ai.canyonroad.agentsh.SysExt",
-			want:   true,
-		},
-		{
-			name:   "real systemextensionsctl output check running state",
-			s:      "ai.canyonroad.agentsh.SysExt	team_id	activated enabled",
-			substr: "activated enabled",
-			want:   true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := contains(tt.s, tt.substr)
-			if got != tt.want {
-				t.Errorf("contains(%q, %q) = %v, want %v", tt.s, tt.substr, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSysExtStatus_JSONTags(t *testing.T) {
 	// Verify that SysExtStatus has the expected structure
 	status := SysExtStatus{
 		Installed:   true,
 		Running:     true,
+		State:       "running",
+		LastExit:    "",
 		Version:     "1.0.0",
 		BundleID:    "ai.canyonroad.agentsh.SysExt",
 		ExtensionID: "ext-123",
@@ -207,5 +137,77 @@ func TestSysExtStatus_JSONTags(t *testing.T) {
 	}
 	if status.ExtensionID != "ext-123" {
 		t.Error("ExtensionID mismatch")
+	}
+	if status.State != "running" {
+		t.Error("State mismatch")
+	}
+}
+
+func TestSysExtManager_Status_LivenessMapping(t *testing.T) {
+	restore := runLivenessCommand
+	defer func() { runLivenessCommand = restore }()
+
+	m := &SysExtManager{bundlePath: "/tmp", bundleID: "ai.canyonroad.agentsh.SysExt"}
+
+	tests := []struct {
+		name            string
+		sysextFails     bool   // true: systemextensionsctl itself fails, so Activated stays false
+		launchctlOut    string // "" injects a launchctl command failure (ignored when sysextFails)
+		wantInstalled   bool
+		wantRunning     bool
+		wantErrSub      string // "" means Error must be empty
+		wantLastExit    string
+		wantState       string
+		wantProbeFailed bool
+	}{
+		{"activated but spawn scheduled", false, launchdSpawnScheduled, true, false, "activated but not running", "exit code 1", "spawn scheduled", false},
+		{"activated and running suppresses historical exit", false, launchdRunningAfterCrash, true, true, "", "", "running", false},
+		{"launchctl failure -> probe failed", false, "", true, false, "could not be verified", "", "", true},
+		// Activated=false here (systemextensionsctl itself failed), so this is
+		// the only row where the `liveness.ProbeFailed ||` half of the Error
+		// condition is load-bearing: the `Activated && !Running` half alone
+		// would not fire since Activated is false.
+		{"systemextensionsctl failure -> not activated, probe failed, error still populated", true, "", false, false, "could not be verified", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runLivenessCommand = func(name string, args ...string) (string, error) {
+				if name == "systemextensionsctl" {
+					if tt.sysextFails {
+						return "", errors.New("no such process")
+					}
+					return sysextListBoth, nil
+				}
+				if tt.launchctlOut == "" {
+					return "", errors.New("Could not find service")
+				}
+				return tt.launchctlOut, nil
+			}
+			status, err := m.Status()
+			if err != nil {
+				t.Fatalf("Status() error = %v", err)
+			}
+			if status.Installed != tt.wantInstalled {
+				t.Errorf("Installed = %v, want %v", status.Installed, tt.wantInstalled)
+			}
+			if status.Running != tt.wantRunning {
+				t.Errorf("Running = %v, want %v", status.Running, tt.wantRunning)
+			}
+			if tt.wantErrSub == "" && status.Error != "" {
+				t.Errorf("Error = %q, want empty", status.Error)
+			}
+			if tt.wantErrSub != "" && !strings.Contains(status.Error, tt.wantErrSub) {
+				t.Errorf("Error = %q, want substring %q", status.Error, tt.wantErrSub)
+			}
+			if status.LastExit != tt.wantLastExit {
+				t.Errorf("LastExit = %q, want %q (historical exits are suppressed while running)", status.LastExit, tt.wantLastExit)
+			}
+			if status.State != tt.wantState {
+				t.Errorf("State = %q, want %q", status.State, tt.wantState)
+			}
+			if status.ProbeFailed != tt.wantProbeFailed {
+				t.Errorf("ProbeFailed = %v, want %v", status.ProbeFailed, tt.wantProbeFailed)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #441.

`detect` (and the tier/status surfaces) reported `esf ✓` from `systemextensionsctl list` "activated enabled" alone, so an activated-but-not-running extension (AMFI-blocked #436, launchd-throttled, crash-looping) scored 90 while enforcing nothing.

## What changed

- New `darwin.CheckSysExtLiveness()`: activation via per-line `systemextensionsctl` parse (exact bundle-ID token + team ID extraction), liveness via `launchctl print system/<TeamID>.ai.canyonroad.agentsh.SysExt` requiring `state = running`; **fail-closed** on every probe failure (`ProbeFailed`), 5s timeouts, stderr folded into single-line diagnostics.
- `caps["esf"]` = running (honest mode selection + protection score); new `caps["esf_activated"]` and `caps["esf_probe_failed"]` preserve the distinctions for scripts; esf backends carry the liveness detail (long details render on a continuation line in the table). The Command Control esf backend's `check_method` corrected `"entitlement"` → `"sysext"`.
- Reason-sensitive tips: `OS_REASON_EXEC` → AMFI/provisionprofile guidance (concrete check + upgrade-not-reinstall per #440); activated-but-not-running → Full Disk Access first (the most common real cause) + `/usr/bin/log show` crash-reason command; probe failure → manual launchctl check. All placeholders resolvable.
- `TierEnterprise` and `SysExtStatus.Running` now require real liveness; `SysExtStatus` gains `State`/`LastExit`/`ProbeFailed` (stub parity for cross-compile). Duplicated activation-grep deleted from all three former call sites.
- Tests: real captured fixtures (including a co-installed neighbor extension and this machine's live broken state), decision-table + injected-runner tests, and mutation-verified pins on every load-bearing mapping (gate exactness, Running/Activated transpositions, tip ordering, LastExit suppression).

## Merge notes

- **Squash-merge only.** The per-task commit history intentionally contains interim states where detect and the tier/status surfaces disagree (Tasks 4–7 are one semantic unit); do not cherry-pick or merge partially.
- **Known limitation** (by design, fail-closed direction preserved): a crash-looping extension is momentarily `running`, so the liveness gate can report esf healthy mid-flap. The durable fix is server-side policy-socket connection reporting — filed as #446 with live evidence.
- Follow-ups: #446 (server-side connection check), #447 (honest-but-unreachable permissions/status surfaces).
- Spec + implementation plan with recorded execution amendments: `docs/superpowers/specs/2026-08-05-issue-441-esf-liveness-detect-design.md`, `docs/superpowers/plans/2026-08-05-issue-441-esf-liveness-detect.md`.

## Verification

- `go build ./...`, `GOOS=windows`, `GOOS=linux`, `go vet ./...` — clean; full `go test ./...` green except the pre-existing sandboxed-Keychain failure in `internal/proxy/secrets/keyring` (present at base).
- Live acceptance on the #441 specimen machine: with the extension crash-looping (`spawn scheduled`), detect reports `esf ✗ / esf_activated ✓` with the launchd diagnostics and the Full-Disk-Access tip, mode falls back; when launchd flaps it to `running`, detect reports `esf ✓ / probe_failed -` consistent with ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)